### PR TITLE
terule: Fixed evaluate kwargs

### DIFF
--- a/setools/policyrep/terule.pxi
+++ b/setools/policyrep/terule.pxi
@@ -100,7 +100,7 @@ cdef class BaseTERule(PolicyRule):
         if self._conditional is None:
             return True
 
-        if self._conditional.evaluate(kwargs):
+        if self._conditional.evaluate(**kwargs):
             return self._conditional_block
         else:
             return not self._conditional_block


### PR DESCRIPTION
Added missing ** to pass kwargs as kwargs instead of as a dictionary.

Signed-off-by: Riechers, Daniel J <daniel.riechers@rockwellcollins.com>