### PR TITLE
Change how differences in AV rules are generated in sediff

### DIFF
--- a/setools/policyrep/terule.pxi
+++ b/setools/policyrep/terule.pxi
@@ -142,6 +142,26 @@ cdef class AVRule(BaseTERule):
         """The rule's default type."""
         raise RuleUseError("{0} rules do not have a default type.".format(self.ruletype))
 
+    def create_expanded(self, source, target, perms):
+        """Create an expanded rule from source, target, and perms."""
+        cdef AVRule r
+        if self.origin is None:
+           r = AVRule.__new__(AVRule)
+           r.policy = self.policy
+           r.key = self.key
+           r.ruletype = self.ruletype
+           r.source = source
+           r.target = target
+           r.tclass = self.tclass
+           r.perms = frozenset(p for p in perms)
+           r._conditional = self._conditional
+           r._conditional_block = self._conditional_block
+           r.origin = self
+           return r
+        else:
+	   # this rule is already expanded.
+           return self
+
     def expand(self):
         """Expand the rule into an equivalent set of rules without attributes."""
         cdef AVRule r


### PR DESCRIPTION
The primary motivation for the change is to correctly handle redundant
rules. Recent changes in the SELinux toolchain added support for an
optimization that removes redundant rules from a policy. These are
conditional rules that are either already specified in unconditional
policy or rules using types that are also specified more generally
through an attribute. Since attributes are always expanded in sediff,
the second type of redundant rules are already effectively removed. But
redundant conditional rules show up as differences when a binary version
of a policy that has been optimized is compared to one that has not been.

A secondary motivation for the change is to reduce memory usage and diff
times. A modern Fedora policy cannot be diffed with a system with less than
32Gb of memory and it takes over four hours to complete.

With this change AV rules are processed by creating a data structure which
consists of nested dictionaries that store BOTH the left and the right
policies. All of the keys are interned strings to save space.

The basic structure is
  rule_db[cond_exp][block_bool][src][tgt][tclass][side]=(perms, rule)
where:
  cond_exp is a boolean expression
  block_bool is either true or false
  src is the source type
  tgt is the target type
  tclass is the target class
  side is either left or right
  perms is the set of permissions for this rule
  rule is the original unexpanded rule

A recent Refpolicy policy requires roughly 7M dictionaries for allow
and 1M dictionaries for dontaudit rules. A recent Fedora policy requires
33M dictrionaries for allow rules and 49M for dontaudit rules.

These changes improve diff times and memory usage.
Without the change
                         Time        Memory Usage
Older Fedora Policy    3 min 17 sec      4.5Gb
Recent Refpolicy       4 min 19 sec      6.0Gb
Recent Fedora Policy   4 hrs  9 min     31.9Gb

With the change
                         Time        Memory Usage
Older Fedora Policy          21 sec      2.4Gb
Recent Refpolicy             26 sec      2.9Gb
Recent Fedora Policy   3 min 41 sec     15.7Gb

Signed-off-by: James Carter <jwcart2@tycho.nsa.gov>