### PR TITLE
Change how differences in AV rules are generated in sediff

### DIFF
--- a/setools/policyrep/terule.pxi
+++ b/setools/policyrep/terule.pxi
@@ -142,6 +142,32 @@ cdef class AVRule(BaseTERule):
         """The rule's default type."""
         raise RuleUseError("{0} rules do not have a default type.".format(self.ruletype))
 
+    def derive_expanded(self, BaseType source, BaseType target, perms):
+        """Derive an expanded rule from source, target, and perms."""
+        cdef AVRule r
+        if self.origin is not None:
+            raise RuleUseError("{0} rule is already expanded.".format(self.ruletype))
+
+        if source is not self.source and source not in self.source:
+            raise RuleUseError("{0} is not {1} and is not in {1}".format(source, self.source))
+        if target is not self.target and target not in self.target:
+            raise RuleUseError("{0} is not {1} and is not in {1}".format(target, self.target))
+        if not perms <= self.perms:
+            raise RuleUseError("Permissions for derived expanded {0} rule are not a subset of the original permissions".format(self.ruletype))
+
+        r = AVRule.__new__(AVRule)
+        r.policy = self.policy
+        r.key = self.key
+        r.ruletype = self.ruletype
+        r.source = source
+        r.target = target
+        r.tclass = self.tclass
+        r.perms = frozenset(p for p in perms)
+        r._conditional = self._conditional
+        r._conditional_block = self._conditional_block
+        r.origin = self
+        return r
+
     def expand(self):
         """Expand the rule into an equivalent set of rules without attributes."""
         cdef AVRule r

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -2900,3 +2900,34 @@ class PolicyDifferenceTestMLStoStandard(unittest.TestCase):
         """NoDiff: no modified ibendportcon rules."""
         self.assertEqual(self.diff.left_policy.ibendportcon_count,
                          len(self.diff.modified_ibendportcons))
+
+
+class PolicyDifferenceTestRedundant(unittest.TestCase):
+
+    """
+    Policy difference test with redundant rules.
+    There should be no policy differences.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.p_left = compile_policy("tests/diff_left.conf")
+        cls.p_right = compile_policy("tests/diff_left_redundant.conf")
+        cls.diff = PolicyDifference(cls.p_left, cls.p_right)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls.p_left.path)
+        os.unlink(cls.p_right.path)
+
+    def test_added_allows(self):
+        """Redundant: no added allow rules."""
+        self.assertFalse(self.diff.added_allows)
+
+    def test_removed_allows(self):
+        """Redundant: no removed allow rules."""
+        self.assertFalse(self.diff.removed_allows)
+
+    def test_modified_allows(self):
+        """Redundant: no modified allow rules."""
+        self.assertFalse(self.diff.modified_allows)

--- a/tests/diff_left.conf
+++ b/tests/diff_left.conf
@@ -409,6 +409,18 @@ type na_union_perm_source, na_union_perm_a, na_union_perm_c;
 type na_union_perm_target, na_union_perm_b;
 neverallow na_union_perm_source na_union_perm_target:infoflow { hi_w med_w low_w };
 
+attribute redundant_rule_attr;
+type redundant_rule_source_1, redundant_rule_attr;
+type redundant_rule_source_2, redundant_rule_attr;
+type redundant_rule_target_1;
+type redundant_rule_target_2;
+bool redundant_rule_bool true;
+allow redundant_rule_attr redundant_rule_target_1:infoflow low_w;
+allow redundant_rule_attr redundant_rule_target_2:infoflow med_w;
+if (redundant_rule_bool) {
+allow redundant_rule_source_2 redundant_rule_target_2:infoflow hi_w;
+}
+
 # type_transition rule differences
 type tt_matched_source;
 type tt_matched_target;

--- a/tests/diff_left_redundant.conf
+++ b/tests/diff_left_redundant.conf
@@ -5,7 +5,7 @@ class infoflow4
 class infoflow5
 class infoflow6
 class infoflow7
-class added_class
+class removed_class
 class modified_add_perm
 class modified_remove_perm
 class modified_change_common
@@ -15,7 +15,6 @@ sid security
 sid unlabeled
 sid fs
 sid file
-sid file_labels
 
 common infoflow
 {
@@ -28,20 +27,20 @@ common infoflow
     ioctl
 }
 
-common added_common
+common removed_common
 {
-    new_com
+    old_com
 }
 
 common modified_remove_perm
 {
     same_perm
+    removed_perm
 }
 
 common modified_add_perm
 {
     matched_perm
-    added_perm
 }
 
 class infoflow
@@ -78,24 +77,24 @@ inherits infoflow
 	super_unmapped
 }
 
-class added_class
+class removed_class
 {
-    new_class_perm
+    null_perm
 }
 
 class modified_add_perm
 {
     same_perm
-    added_perm
 }
 
 class modified_remove_perm
 {
     same_perm
+    removed_perm
 }
 
 class modified_change_common
-inherits added_common
+inherits removed_common
 
 # matching defaults:
 default_user infoflow source;
@@ -104,23 +103,23 @@ default_type infoflow source;
 default_range infoflow source low;
 
 # added:
-default_user infoflow2 target;
-default_range infoflow2 source low;
 
 # removed:
+default_role infoflow3 source;
+default_range infoflow3 target high;
 
 # modified:
-default_type infoflow4 target;
-default_range infoflow4 target low;
+default_type infoflow4 source;
+default_range infoflow4 source low;
 
 # modified range:
-default_range infoflow5 target high;
+default_range infoflow5 target low;
 
 # modified both
-default_range infoflow6 target low;
+default_range infoflow6 source high;
 
-sensitivity s0 alias { al1 };
-sensitivity s1 alias { al3 al4 };
+sensitivity s0 alias { al1 al2 };
+sensitivity s1 alias { al3 };
 sensitivity s2;
 sensitivity s3;
 sensitivity s40;
@@ -129,55 +128,55 @@ sensitivity s42;
 sensitivity s43;
 sensitivity s44;
 sensitivity s45;
-sensitivity s46;
+sensitivity s47;
 
-dominance { s0 s1 s2 s3 s40 s41 s42 s43 s44 s45 s46 }
+dominance { s0 s1 s2 s3 s40 s41 s42 s43 s44 s45 s47 }
 
-category c0 alias { spam };
-category c1 alias { foo bar };
+category c0 alias { spam eggs };
+category c1 alias { bar };
 category c2;
 category c3;
 category c4;
-category c6;
+category c5;
 
 #level decl
 level s0:c0.c4;
 level s1:c0.c4;
 level s2:c0.c4;
 level s3:c0.c4;
-level s40:c1,c3;
-level s41:c0.c3;
+level s40:c1;
+level s41:c0.c4;
 level s42:c0.c4;
 level s43:c0.c4;
 level s44:c0.c4;
 level s45:c0.c4;
-level s46:c0.c4;
+level s47:c0.c4;
 
 # matching mls constraints
 mlsconstrain infoflow hi_r ((l1 dom l2) or (t1 == mls_exempt));
 
 # added mls constraint
-mlsconstrain infoflow3 null ((l1 domby l2 and h1 domby h2) or (t1 != mls_exempt));
 
 # removed mls constraint
+mlsconstrain infoflow4 hi_w ((l1 domby l2 and h1 domby h2) or (t1 == mls_exempt));
 
 # remove/add mls constraint (expression change)
-mlsconstrain infoflow5 hi_r ((l1 domby l2 and h1 incomp h2) or (t1 == mls_exempt));
+mlsconstrain infoflow5 hi_r ((l1 domby l2 and h1 dom h2) or (t1 == mls_exempt));
 
 # matching mls validatetrans
 mlsvalidatetrans infoflow (h1 == h2 or t3 == system);
 
 # added mls validatetrans
-mlsvalidatetrans infoflow3 ((l1 == l2 and h1 == h2) or t3 == mls_exempt);
 
 # removed mls validatetrans
+mlsvalidatetrans infoflow4 ((l1 == l2 and h1 == h2) or t3 == mls_exempt);
 
 # remove/add mls validatetrans (expression change)
-mlsvalidatetrans infoflow5 ((l1 incomp l2 and h1 domby h2) or (t3 == mls_exempt));
+mlsvalidatetrans infoflow5 ((l1 dom l2 and h1 dom h2) or (t3 == mls_exempt));
 
 attribute mls_exempt;
 attribute an_attr;
-attribute added_attr;
+attribute removed_attr;
 
 type system;
 role system;
@@ -186,32 +185,32 @@ role system types system;
 ################################################################################
 # Type enforcement declarations and rules
 
-type added_type;
+type removed_type;
 
-type modified_remove_attr;
+type modified_remove_attr, an_attr;
 
-type modified_remove_alias;
+type modified_remove_alias alias an_alias;
 
 type modified_remove_permissive;
+permissive modified_remove_permissive;
 
-type modified_add_attr, an_attr;
+type modified_add_attr;
 
-type modified_add_alias alias an_alias;
+type modified_add_alias;
 
 type modified_add_permissive;
-permissive modified_add_permissive;
 
-role added_role;
+role removed_role;
 
 role modified_add_type;
-role modified_add_type types { system };
 
 role modified_remove_type;
+role modified_remove_type types { system };
 
 # booleans
 bool same_bool true;
-bool added_bool true;
-bool modified_bool true;
+bool removed_bool true;
+bool modified_bool false;
 
 # Allow rule differences
 type matched_source;
@@ -220,55 +219,52 @@ allow matched_source matched_target:infoflow hi_w;
 
 type removed_rule_source;
 type removed_rule_target;
+allow removed_rule_source removed_rule_target:infoflow hi_r;
 
 type added_rule_source;
 type added_rule_target;
-allow added_rule_source added_rule_target:infoflow med_w;
 
 type modified_rule_add_perms;
-allow modified_rule_add_perms self:infoflow { hi_r hi_w };
+allow modified_rule_add_perms self:infoflow hi_r;
 
 type modified_rule_remove_perms;
-allow modified_rule_remove_perms self:infoflow low_w;
+allow modified_rule_remove_perms self:infoflow { low_r low_w };
 
 type modified_rule_add_remove_perms;
-allow modified_rule_add_remove_perms self:infoflow2 { low_w super_r };
+allow modified_rule_add_remove_perms self:infoflow2 { low_w super_w };
 
-allow added_type self:infoflow2 med_w;
+allow removed_type self:infoflow3 null;
 
 type move_to_bool;
 bool move_to_bool_b false;
-if (move_to_bool_b) {
 allow move_to_bool self:infoflow4 hi_w;
-}
 
 type move_from_bool;
 bool move_from_bool_b false;
+if (move_from_bool_b) {
 allow move_from_bool self:infoflow4 hi_r;
+}
 
 type switch_block;
 bool switch_block_b false;
 if (switch_block_b) {
 allow system switch_block:infoflow5 hi_r;
-} else {
 allow system switch_block:infoflow6 hi_r;
+} else {
 allow system switch_block:infoflow7 hi_r;
 }
 
 attribute match_rule_by_attr;
 type match_rule_by_attr_A_t, match_rule_by_attr;
 type match_rule_by_attr_B_t, match_rule_by_attr;
-allow match_rule_by_attr_A_t self:infoflow2 super_w;
-allow match_rule_by_attr_B_t self:infoflow2 super_w;
+allow match_rule_by_attr self:infoflow2 super_w;
 
 attribute union_perm_a;
 attribute union_perm_b;
 attribute union_perm_c;
 type union_perm_source, union_perm_a, union_perm_c;
 type union_perm_target, union_perm_b;
-allow union_perm_a union_perm_b:infoflow hi_w;
-allow union_perm_c union_perm_target:infoflow med_w;
-allow union_perm_source union_perm_target:infoflow low_w;
+allow union_perm_source union_perm_target:infoflow { hi_w med_w low_w };
 
 # Auditallow rule differences
 type aa_matched_source;
@@ -277,55 +273,52 @@ auditallow aa_matched_source aa_matched_target:infoflow hi_w;
 
 type aa_removed_rule_source;
 type aa_removed_rule_target;
+auditallow aa_removed_rule_source aa_removed_rule_target:infoflow hi_r;
 
 type aa_added_rule_source;
 type aa_added_rule_target;
-auditallow aa_added_rule_source aa_added_rule_target:infoflow med_w;
 
 type aa_modified_rule_add_perms;
-auditallow aa_modified_rule_add_perms self:infoflow { hi_r hi_w };
+auditallow aa_modified_rule_add_perms self:infoflow hi_r;
 
 type aa_modified_rule_remove_perms;
-auditallow aa_modified_rule_remove_perms self:infoflow low_w;
+auditallow aa_modified_rule_remove_perms self:infoflow { low_r low_w };
 
 type aa_modified_rule_add_remove_perms;
-auditallow aa_modified_rule_add_remove_perms self:infoflow2 { low_w super_r };
+auditallow aa_modified_rule_add_remove_perms self:infoflow2 { low_w super_w };
 
-auditallow added_type self:infoflow7 super_none;
+auditallow removed_type self:infoflow7 super_unmapped;
 
 type aa_move_to_bool;
 bool aa_move_to_bool_b false;
-if (aa_move_to_bool_b) {
 auditallow aa_move_to_bool self:infoflow4 hi_w;
-}
 
 type aa_move_from_bool;
 bool aa_move_from_bool_b false;
+if (aa_move_from_bool_b) {
 auditallow aa_move_from_bool self:infoflow4 hi_r;
+}
 
 type aa_switch_block;
 bool aa_switch_block_b false;
 if (aa_switch_block_b) {
 auditallow system aa_switch_block:infoflow5 hi_r;
-} else {
 auditallow system aa_switch_block:infoflow6 hi_r;
+} else {
 auditallow system aa_switch_block:infoflow7 hi_r;
 }
 
 attribute aa_match_rule_by_attr;
 type aa_match_rule_by_attr_A_t, aa_match_rule_by_attr;
 type aa_match_rule_by_attr_B_t, aa_match_rule_by_attr;
-auditallow aa_match_rule_by_attr_A_t self:infoflow2 super_w;
-auditallow aa_match_rule_by_attr_B_t self:infoflow2 super_w;
+auditallow aa_match_rule_by_attr self:infoflow2 super_w;
 
 attribute aa_union_perm_a;
 attribute aa_union_perm_b;
 attribute aa_union_perm_c;
 type aa_union_perm_source, aa_union_perm_a, aa_union_perm_c;
 type aa_union_perm_target, aa_union_perm_b;
-auditallow aa_union_perm_a aa_union_perm_b:infoflow hi_w;
-auditallow aa_union_perm_c aa_union_perm_target:infoflow med_w;
-auditallow aa_union_perm_source aa_union_perm_target:infoflow low_w;
+auditallow aa_union_perm_source aa_union_perm_target:infoflow { hi_w med_w low_w };
 
 # Dontaudit rule differences
 type da_matched_source;
@@ -334,55 +327,52 @@ dontaudit da_matched_source da_matched_target:infoflow hi_w;
 
 type da_removed_rule_source;
 type da_removed_rule_target;
+dontaudit da_removed_rule_source da_removed_rule_target:infoflow hi_r;
 
 type da_added_rule_source;
 type da_added_rule_target;
-dontaudit da_added_rule_source da_added_rule_target:infoflow med_w;
 
 type da_modified_rule_add_perms;
-dontaudit da_modified_rule_add_perms self:infoflow { hi_r hi_w };
+dontaudit da_modified_rule_add_perms self:infoflow hi_r;
 
 type da_modified_rule_remove_perms;
-dontaudit da_modified_rule_remove_perms self:infoflow low_w;
+dontaudit da_modified_rule_remove_perms self:infoflow { low_r low_w };
 
 type da_modified_rule_add_remove_perms;
-dontaudit da_modified_rule_add_remove_perms self:infoflow2 { low_w super_r };
+dontaudit da_modified_rule_add_remove_perms self:infoflow2 { low_w super_w };
 
-dontaudit added_type self:infoflow7 super_none;
+dontaudit removed_type self:infoflow7 super_both;
 
 type da_move_to_bool;
 bool da_move_to_bool_b false;
-if (da_move_to_bool_b) {
 dontaudit da_move_to_bool self:infoflow4 hi_w;
-}
 
 type da_move_from_bool;
 bool da_move_from_bool_b false;
+if (da_move_from_bool_b) {
 dontaudit da_move_from_bool self:infoflow4 hi_r;
+}
 
 type da_switch_block;
 bool da_switch_block_b false;
 if (da_switch_block_b) {
 dontaudit system da_switch_block:infoflow5 hi_r;
-} else {
 dontaudit system da_switch_block:infoflow6 hi_r;
+} else {
 dontaudit system da_switch_block:infoflow7 hi_r;
 }
 
 attribute da_match_rule_by_attr;
 type da_match_rule_by_attr_A_t, da_match_rule_by_attr;
 type da_match_rule_by_attr_B_t, da_match_rule_by_attr;
-dontaudit da_match_rule_by_attr_A_t self:infoflow2 super_w;
-dontaudit da_match_rule_by_attr_B_t self:infoflow2 super_w;
+dontaudit da_match_rule_by_attr self:infoflow2 super_w;
 
 attribute da_union_perm_a;
 attribute da_union_perm_b;
 attribute da_union_perm_c;
 type da_union_perm_source, da_union_perm_a, da_union_perm_c;
 type da_union_perm_target, da_union_perm_b;
-dontaudit da_union_perm_a da_union_perm_b:infoflow hi_w;
-dontaudit da_union_perm_c da_union_perm_target:infoflow med_w;
-dontaudit da_union_perm_source da_union_perm_target:infoflow low_w;
+dontaudit da_union_perm_source da_union_perm_target:infoflow { hi_w med_w low_w };
 
 # Neverallow rule differences
 type na_matched_source;
@@ -391,36 +381,33 @@ neverallow na_matched_source na_matched_target:infoflow hi_w;
 
 type na_removed_rule_source;
 type na_removed_rule_target;
+neverallow na_removed_rule_source na_removed_rule_target:infoflow hi_r;
 
 type na_added_rule_source;
 type na_added_rule_target;
-neverallow na_added_rule_source na_added_rule_target:infoflow med_w;
 
 type na_modified_rule_add_perms;
-neverallow na_modified_rule_add_perms self:infoflow { hi_r hi_w };
+neverallow na_modified_rule_add_perms self:infoflow hi_r;
 
 type na_modified_rule_remove_perms;
-neverallow na_modified_rule_remove_perms self:infoflow low_w;
+neverallow na_modified_rule_remove_perms self:infoflow { low_r low_w };
 
 type na_modified_rule_add_remove_perms;
-neverallow na_modified_rule_add_remove_perms self:infoflow2 { low_w super_r };
+neverallow na_modified_rule_add_remove_perms self:infoflow2 { low_w super_w };
 
-neverallow added_type self:added_class new_class_perm;
+neverallow removed_type self:removed_class null_perm;
 
 attribute na_match_rule_by_attr;
 type na_match_rule_by_attr_A_t, na_match_rule_by_attr;
 type na_match_rule_by_attr_B_t, na_match_rule_by_attr;
-neverallow na_match_rule_by_attr_A_t self:infoflow2 super_w;
-neverallow na_match_rule_by_attr_B_t self:infoflow2 super_w;
+neverallow na_match_rule_by_attr self:infoflow2 super_w;
 
 attribute na_union_perm_a;
 attribute na_union_perm_b;
 attribute na_union_perm_c;
 type na_union_perm_source, na_union_perm_a, na_union_perm_c;
 type na_union_perm_target, na_union_perm_b;
-neverallow na_union_perm_a na_union_perm_b:infoflow hi_w;
-neverallow na_union_perm_c na_union_perm_target:infoflow med_w;
-neverallow na_union_perm_source na_union_perm_target:infoflow low_w;
+neverallow na_union_perm_source na_union_perm_target:infoflow { hi_w med_w low_w };
 
 # type_transition rule differences
 type tt_matched_source;
@@ -429,33 +416,33 @@ type_transition tt_matched_source tt_matched_target:infoflow system;
 
 type tt_removed_rule_source;
 type tt_removed_rule_target;
+type_transition tt_removed_rule_source tt_removed_rule_target:infoflow system;
 
 type tt_added_rule_source;
 type tt_added_rule_target;
-type_transition tt_added_rule_source tt_added_rule_target:infoflow system;
 
 type tt_old_type;
 type tt_new_type;
-type_transition tt_matched_source system:infoflow tt_new_type;
+type_transition tt_matched_source system:infoflow tt_old_type;
 
-type_transition added_type system:infoflow4 system;
+type_transition removed_type system:infoflow4 system;
 
 type tt_move_to_bool;
 bool tt_move_to_bool_b false;
-if (tt_move_to_bool_b) {
 type_transition tt_move_to_bool system:infoflow3 system;
-}
 
 type tt_move_from_bool;
 bool tt_move_from_bool_b false;
+if (tt_move_from_bool_b) {
 type_transition tt_move_from_bool system:infoflow4 system;
+}
 
 type tt_switch_block;
 bool tt_switch_block_b false;
 if (tt_switch_block_b) {
 type_transition system tt_switch_block:infoflow5 system;
-} else {
 type_transition system tt_switch_block:infoflow6 system;
+} else {
 type_transition system tt_switch_block:infoflow7 system;
 }
 
@@ -478,33 +465,33 @@ type_change tc_matched_source tc_matched_target:infoflow system;
 
 type tc_removed_rule_source;
 type tc_removed_rule_target;
+type_change tc_removed_rule_source tc_removed_rule_target:infoflow system;
 
 type tc_added_rule_source;
 type tc_added_rule_target;
-type_change tc_added_rule_source tc_added_rule_target:infoflow system;
 
 type tc_old_type;
 type tc_new_type;
-type_change tc_matched_source system:infoflow tc_new_type;
+type_change tc_matched_source system:infoflow tc_old_type;
 
-type_change added_type system:infoflow4 system;
+type_change removed_type system:infoflow4 system;
 
 type tc_move_to_bool;
 bool tc_move_to_bool_b false;
-if (tc_move_to_bool_b) {
 type_change tc_move_to_bool system:infoflow3 system;
-}
 
 type tc_move_from_bool;
 bool tc_move_from_bool_b false;
+if (tc_move_from_bool_b) {
 type_change tc_move_from_bool system:infoflow4 system;
+}
 
 type tc_switch_block;
 bool tc_switch_block_b false;
 if (tc_switch_block_b) {
 type_change system tc_switch_block:infoflow5 system;
-} else {
 type_change system tc_switch_block:infoflow6 system;
+} else {
 type_change system tc_switch_block:infoflow7 system;
 }
 
@@ -527,33 +514,33 @@ type_member tm_matched_source tm_matched_target:infoflow system;
 
 type tm_removed_rule_source;
 type tm_removed_rule_target;
+type_member tm_removed_rule_source tm_removed_rule_target:infoflow system;
 
 type tm_added_rule_source;
 type tm_added_rule_target;
-type_member tm_added_rule_source tm_added_rule_target:infoflow system;
 
 type tm_old_type;
 type tm_new_type;
-type_member tm_matched_source system:infoflow tm_new_type;
+type_member tm_matched_source system:infoflow tm_old_type;
 
-type_member added_type system:infoflow4 system;
+type_member removed_type system:infoflow4 system;
 
 type tm_move_to_bool;
 bool tm_move_to_bool_b false;
-if (tm_move_to_bool_b) {
 type_member tm_move_to_bool system:infoflow3 system;
-}
 
 type tm_move_from_bool;
 bool tm_move_from_bool_b false;
+if (tm_move_from_bool_b) {
 type_member tm_move_from_bool system:infoflow4 system;
+}
 
 type tm_switch_block;
 bool tm_switch_block_b false;
 if (tm_switch_block_b) {
 type_member system tm_switch_block:infoflow5 system;
-} else {
 type_member system tm_switch_block:infoflow6 system;
+} else {
 type_member system tm_switch_block:infoflow7 system;
 }
 
@@ -576,32 +563,32 @@ range_transition rt_matched_source rt_matched_target:infoflow s0;
 
 type rt_removed_rule_source;
 type rt_removed_rule_target;
+range_transition rt_removed_rule_source rt_removed_rule_target:infoflow s1;
 
 type rt_added_rule_source;
 type rt_added_rule_target;
-range_transition rt_added_rule_source rt_added_rule_target:infoflow s3;
 
-range_transition rt_matched_source system:infoflow s0:c0,c4 - s1:c0.c2,c4;
+range_transition rt_matched_source system:infoflow s2:c0 - s3:c0.c2;
 
-range_transition added_type system:infoflow4 s3;
+range_transition removed_type system:infoflow4 s1;
 
 # range transitions cannot be conditional.
 #type rt_move_to_bool;
 #bool rt_move_to_bool_b false;
-#if (rt_move_to_bool_b) {
 #range_transition rt_move_to_bool system:infoflow3 s0;
-#}
 
 #type rt_move_from_bool;
 #bool rt_move_from_bool_b false;
+#if (rt_move_from_bool_b) {
 #range_transition rt_move_from_bool system:infoflow4 s0;
+#}
 
 #type rt_switch_block;
 #bool rt_switch_block_b false;
 #if (rt_switch_block_b) {
 #range_transition system rt_switch_block:infoflow5 s0;
-#} else {
 #range_transition system rt_switch_block:infoflow6 s0;
+#} else {
 #range_transition system rt_switch_block:infoflow7 s0;
 #}
 
@@ -614,7 +601,7 @@ attribute rt_unioned_perm_via_attr;
 type rt_unioned_perm_via_attr_A_t, rt_unioned_perm_via_attr;
 type rt_unioned_perm_via_attr_B_t, rt_unioned_perm_via_attr;
 range_transition rt_unioned_perm_via_attr system:infoflow2 s0;
-range_transition rt_unioned_perm_via_attr_B_t system:infoflow2 s0;
+range_transition rt_unioned_perm_via_attr_A_t system:infoflow2 s0;
 
 # role allow
 role matched_source_r;
@@ -623,12 +610,12 @@ allow matched_source_r matched_target_r;
 
 role removed_rule_source_r;
 role removed_rule_target_r;
+allow removed_rule_source_r removed_rule_target_r;
 
 role added_rule_source_r;
 role added_rule_target_r;
-allow added_rule_source_r added_rule_target_r;
 
-allow added_role system;
+allow removed_role system;
 
 # role_transition
 role role_tr_matched_source;
@@ -637,16 +624,16 @@ role_transition role_tr_matched_source role_tr_matched_target:infoflow system;
 
 role role_tr_removed_rule_source;
 type role_tr_removed_rule_target;
+role_transition role_tr_removed_rule_source role_tr_removed_rule_target:infoflow5 system;
 
 role role_tr_added_rule_source;
 type role_tr_added_rule_target;
-role_transition role_tr_added_rule_source role_tr_added_rule_target:infoflow6 system;
 
-role_transition added_role system:infoflow4 system;
+role_transition removed_role system:infoflow4 system;
 
 role role_tr_old_role;
 role role_tr_new_role;
-role_transition role_tr_matched_source role_tr_matched_target:infoflow3 role_tr_new_role;
+role_transition role_tr_matched_source role_tr_matched_target:infoflow3 role_tr_old_role;
 
 # Allowxperm rule differences
 type ax_matched_source;
@@ -655,36 +642,33 @@ allowxperm ax_matched_source ax_matched_target:infoflow ioctl 0x0001;
 
 type ax_removed_rule_source;
 type ax_removed_rule_target;
+allowxperm ax_removed_rule_source ax_removed_rule_target:infoflow ioctl 0x0002;
 
 type ax_added_rule_source;
 type ax_added_rule_target;
-allowxperm ax_added_rule_source ax_added_rule_target:infoflow ioctl 0x0002;
 
 type ax_modified_rule_add_perms;
-allowxperm ax_modified_rule_add_perms self:infoflow ioctl { 0x0004 0x000f };
+allowxperm ax_modified_rule_add_perms self:infoflow ioctl 0x0004;
 
 type ax_modified_rule_remove_perms;
-allowxperm ax_modified_rule_remove_perms self:infoflow ioctl 0x0005;
+allowxperm ax_modified_rule_remove_perms self:infoflow ioctl { 0x0005 0x0006 };
 
 type ax_modified_rule_add_remove_perms;
-allowxperm ax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0006 0x0008 };
+allowxperm ax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0007 0x0008 };
 
-allowxperm added_type self:infoflow7 ioctl 0x0009;
+allowxperm removed_type self:infoflow7 ioctl 0x0009;
 
 attribute ax_match_rule_by_attr;
 type ax_match_rule_by_attr_A_t, ax_match_rule_by_attr;
 type ax_match_rule_by_attr_B_t, ax_match_rule_by_attr;
-allowxperm ax_match_rule_by_attr_A_t self:infoflow2 ioctl 0x000a;
-allowxperm ax_match_rule_by_attr_B_t self:infoflow2 ioctl 0x000a;
+allowxperm ax_match_rule_by_attr self:infoflow2 ioctl 0x000a;
 
 attribute ax_union_perm_a;
 attribute ax_union_perm_b;
 attribute ax_union_perm_c;
 type ax_union_perm_source, ax_union_perm_a, ax_union_perm_c;
 type ax_union_perm_target, ax_union_perm_b;
-allowxperm ax_union_perm_a ax_union_perm_b:infoflow ioctl 0x1;
-allowxperm ax_union_perm_c ax_union_perm_target:infoflow ioctl 0x2;
-allowxperm ax_union_perm_source ax_union_perm_target:infoflow ioctl 0x3;
+allowxperm ax_union_perm_source ax_union_perm_target:infoflow ioctl { 0x1-0x3 };
 
 # Auditallowxperm rule differences
 type aax_matched_source;
@@ -693,36 +677,33 @@ auditallowxperm aax_matched_source aax_matched_target:infoflow ioctl 0x0001;
 
 type aax_removed_rule_source;
 type aax_removed_rule_target;
+auditallowxperm aax_removed_rule_source aax_removed_rule_target:infoflow ioctl 0x0002;
 
 type aax_added_rule_source;
 type aax_added_rule_target;
-auditallowxperm aax_added_rule_source aax_added_rule_target:infoflow ioctl 0x0002;
 
 type aax_modified_rule_add_perms;
-auditallowxperm aax_modified_rule_add_perms self:infoflow ioctl { 0x0004 0x000f };
+auditallowxperm aax_modified_rule_add_perms self:infoflow ioctl 0x0004;
 
 type aax_modified_rule_remove_perms;
-auditallowxperm aax_modified_rule_remove_perms self:infoflow ioctl 0x0005;
+auditallowxperm aax_modified_rule_remove_perms self:infoflow ioctl { 0x0005 0x0006 };
 
 type aax_modified_rule_add_remove_perms;
-auditallowxperm aax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0006 0x0008 };
+auditallowxperm aax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0007 0x0008 };
 
-auditallowxperm added_type self:infoflow7 ioctl 0x0009;
+auditallowxperm removed_type self:infoflow7 ioctl 0x0009;
 
 attribute aax_match_rule_by_attr;
 type aax_match_rule_by_attr_A_t, aax_match_rule_by_attr;
 type aax_match_rule_by_attr_B_t, aax_match_rule_by_attr;
-auditallowxperm aax_match_rule_by_attr_A_t self:infoflow2 ioctl 0x000a;
-auditallowxperm aax_match_rule_by_attr_B_t self:infoflow2 ioctl 0x000a;
+auditallowxperm aax_match_rule_by_attr self:infoflow2 ioctl 0x000a;
 
 attribute aax_union_perm_a;
 attribute aax_union_perm_b;
 attribute aax_union_perm_c;
 type aax_union_perm_source, aax_union_perm_a, aax_union_perm_c;
 type aax_union_perm_target, aax_union_perm_b;
-auditallowxperm aax_union_perm_a aax_union_perm_b:infoflow ioctl 0x1;
-auditallowxperm aax_union_perm_c aax_union_perm_target:infoflow ioctl 0x2;
-auditallowxperm aax_union_perm_source aax_union_perm_target:infoflow ioctl 0x3;
+auditallowxperm aax_union_perm_source aax_union_perm_target:infoflow ioctl { 0x1-0x3 };
 
 # Neverallowxperm rule differences
 type nax_matched_source;
@@ -731,36 +712,33 @@ neverallowxperm nax_matched_source nax_matched_target:infoflow ioctl 0x0001;
 
 type nax_removed_rule_source;
 type nax_removed_rule_target;
+neverallowxperm nax_removed_rule_source nax_removed_rule_target:infoflow ioctl 0x0002;
 
 type nax_added_rule_source;
 type nax_added_rule_target;
-neverallowxperm nax_added_rule_source nax_added_rule_target:infoflow ioctl 0x0002;
 
 type nax_modified_rule_add_perms;
-neverallowxperm nax_modified_rule_add_perms self:infoflow ioctl { 0x0004 0x000f };
+neverallowxperm nax_modified_rule_add_perms self:infoflow ioctl 0x0004;
 
 type nax_modified_rule_remove_perms;
-neverallowxperm nax_modified_rule_remove_perms self:infoflow ioctl 0x0005;
+neverallowxperm nax_modified_rule_remove_perms self:infoflow ioctl { 0x0005 0x0006 };
 
 type nax_modified_rule_add_remove_perms;
-neverallowxperm nax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0006 0x0008 };
+neverallowxperm nax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0007 0x0008 };
 
-neverallowxperm added_type self:infoflow7 ioctl 0x0009;
+neverallowxperm removed_type self:infoflow7 ioctl 0x0009;
 
 attribute nax_match_rule_by_attr;
 type nax_match_rule_by_attr_A_t, nax_match_rule_by_attr;
 type nax_match_rule_by_attr_B_t, nax_match_rule_by_attr;
-neverallowxperm nax_match_rule_by_attr_A_t self:infoflow2 ioctl 0x000a;
-neverallowxperm nax_match_rule_by_attr_B_t self:infoflow2 ioctl 0x000a;
+neverallowxperm nax_match_rule_by_attr self:infoflow2 ioctl 0x000a;
 
 attribute nax_union_perm_a;
 attribute nax_union_perm_b;
 attribute nax_union_perm_c;
 type nax_union_perm_source, nax_union_perm_a, nax_union_perm_c;
 type nax_union_perm_target, nax_union_perm_b;
-neverallowxperm nax_union_perm_a nax_union_perm_b:infoflow ioctl 0x1;
-neverallowxperm nax_union_perm_c nax_union_perm_target:infoflow ioctl 0x2;
-neverallowxperm nax_union_perm_source nax_union_perm_target:infoflow ioctl 0x3;
+neverallowxperm nax_union_perm_source nax_union_perm_target:infoflow ioctl { 0x1-0x3 };
 
 # Dontauditxperm rule differences
 type dax_matched_source;
@@ -769,36 +747,33 @@ dontauditxperm dax_matched_source dax_matched_target:infoflow ioctl 0x0001;
 
 type dax_removed_rule_source;
 type dax_removed_rule_target;
+dontauditxperm dax_removed_rule_source dax_removed_rule_target:infoflow ioctl 0x0002;
 
 type dax_added_rule_source;
 type dax_added_rule_target;
-dontauditxperm dax_added_rule_source dax_added_rule_target:infoflow ioctl 0x0002;
 
 type dax_modified_rule_add_perms;
-dontauditxperm dax_modified_rule_add_perms self:infoflow ioctl { 0x0004 0x000f };
+dontauditxperm dax_modified_rule_add_perms self:infoflow ioctl 0x0004;
 
 type dax_modified_rule_remove_perms;
-dontauditxperm dax_modified_rule_remove_perms self:infoflow ioctl 0x0005;
+dontauditxperm dax_modified_rule_remove_perms self:infoflow ioctl { 0x0005 0x0006 };
 
 type dax_modified_rule_add_remove_perms;
-dontauditxperm dax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0006 0x0008 };
+dontauditxperm dax_modified_rule_add_remove_perms self:infoflow2 ioctl { 0x0007 0x0008 };
 
-dontauditxperm added_type self:infoflow7 ioctl 0x0009;
+dontauditxperm removed_type self:infoflow7 ioctl 0x0009;
 
 attribute dax_match_rule_by_attr;
 type dax_match_rule_by_attr_A_t, dax_match_rule_by_attr;
 type dax_match_rule_by_attr_B_t, dax_match_rule_by_attr;
-dontauditxperm dax_match_rule_by_attr_A_t self:infoflow2 ioctl 0x000a;
-dontauditxperm dax_match_rule_by_attr_B_t self:infoflow2 ioctl 0x000a;
+dontauditxperm dax_match_rule_by_attr self:infoflow2 ioctl 0x000a;
 
 attribute dax_union_perm_a;
 attribute dax_union_perm_b;
 attribute dax_union_perm_c;
 type dax_union_perm_source, dax_union_perm_a, dax_union_perm_c;
 type dax_union_perm_target, dax_union_perm_b;
-dontauditxperm dax_union_perm_a dax_union_perm_b:infoflow ioctl 0x1;
-dontauditxperm dax_union_perm_c dax_union_perm_target:infoflow ioctl 0x2;
-dontauditxperm dax_union_perm_source dax_union_perm_target:infoflow ioctl 0x3;
+dontauditxperm dax_union_perm_source dax_union_perm_target:infoflow ioctl { 0x1-0x3 };
 
 attribute redundant_rule_attr;
 type redundant_rule_source_1, redundant_rule_attr;
@@ -809,7 +784,8 @@ bool redundant_rule_bool true;
 allow redundant_rule_attr redundant_rule_target_1:infoflow low_w;
 allow redundant_rule_attr redundant_rule_target_2:infoflow med_w;
 if (redundant_rule_bool) {
-   allow redundant_rule_source_2 redundant_rule_target_2:infoflow hi_w;
+   allow redundant_rule_source_1 redundant_rule_target_1:infoflow low_w;
+   allow redundant_rule_source_2 redundant_rule_target_2:infoflow { med_w hi_w };
 }
 
 ################################################################################
@@ -821,31 +797,31 @@ typebounds match_parent match_child;
 # removed typebounds
 type removed_parent;
 type removed_child;
+typebounds removed_parent removed_child;
 
 # added typebounds
 type added_parent;
 type added_child;
-typebounds added_parent added_child;
 
 # modified typebounds
 type mod_parent_removed;
 type mod_parent_added;
 type mod_child;
-typebounds mod_parent_added mod_child;
+typebounds mod_parent_removed mod_child;
 
 # policycaps
 policycap open_perms;
-policycap always_check_network;
+policycap network_peer_controls;
 
 #users
 user system roles system level s0 range s0;
 
-user added_user roles system level s1 range s1;
+user removed_user roles system level s0 range s0;
 
-user modified_add_role roles { system added_role } level s2 range s2;
-user modified_remove_role roles system level s2 range s2;
-user modified_change_level roles system level s2:c1 range s2:c1 - s2:c0,c1;
-user modified_change_range roles system level s3:c1 range s3:c1 - s3:c1.c4;
+user modified_add_role roles system level s2 range s2;
+user modified_remove_role roles { system removed_role } level s2 range s2;
+user modified_change_level roles system level s2:c0 range s2:c0 - s2:c0,c1;
+user modified_change_range roles system level s3:c1 range s3:c1 - s3:c1.c3;
 
 # matching constraints
 constrain infoflow hi_w (u1 == u2 or t1 == system);
@@ -853,12 +829,12 @@ constrain infoflow hi_w (t1 == t2 or t1 == system);
 constrain infoflow hi_r (r1 == r2 or t1 == system);
 
 # added constraint
-constrain infoflow3 null (u1 != u2);
 
 # removed constraint
+constrain infoflow4 hi_w (u1 != u2);
 
 # remove/add constraint (expression change)
-constrain infoflow5 hi_r ((u1 == u2 and r1 == r2) or (t1 != system));
+constrain infoflow5 hi_r ((u1 == u2 and r1 == r2) or (t1 == system));
 
 # matching validatetrans
 validatetrans infoflow (u1 == u2 or t3 == system);
@@ -866,92 +842,91 @@ validatetrans infoflow (r1 == r2 or t3 == system);
 validatetrans infoflow2 (u1 == u2 or t3 == system);
 
 # added validatetrans
-validatetrans infoflow3 (t1 == t2 or t3 == system);
 
 # removed validatetrans
+validatetrans infoflow4 (u1 == u2 or t3 == system);
 
 # remove/add validatetrans (expression change)
-validatetrans infoflow5 ((u1 != u2 and r1 == r2) or (t3 == system));
+validatetrans infoflow5 ((u1 == u2 and r1 != r2) or (t3 == system));
 
 #isids
 sid kernel system:system:system:s0
 sid security system:system:system:s0
 sid unlabeled system:system:system:s0
-sid fs system:system:system:s0
+sid fs removed_user:system:system:s0
 sid file system:system:system:s0
-sid file_labels added_user:system:system:s1
 
 #fs_use
 fs_use_trans devpts system:object_r:system:s0;
 fs_use_xattr ext3 system:object_r:system:s0;
 fs_use_task pipefs system:object_r:system:s0;
-fs_use_xattr added_fsuse system:object_r:system:s0;
-fs_use_trans modified_fsuse added_user:object_r:system:s1;
+fs_use_task removed_fsuse system:object_r:system:s0;
+fs_use_trans modified_fsuse removed_user:object_r:system:s0;
 
 #genfscon
 genfscon proc / system:object_r:system:s0
 genfscon proc /sys system:object_r:system:s0
 genfscon selinuxfs / system:object_r:system:s0
-genfscon added_genfs / added_user:object_r:system:s0
-genfscon change_path /new system:object_r:system:s0
-genfscon modified_genfs / -s added_user:object_r:system:s0
+genfscon removed_genfs / system:object_r:system:s0
+genfscon change_path /old system:object_r:system:s0
+genfscon modified_genfs / -s removed_user:object_r:system:s0
 
 # matched portcons
 portcon tcp 80 system:object_r:system:s0
 portcon udp 80 system:object_r:system:s0
 portcon udp 30-40 system:object_r:system:s0
 
-# added portcons
-portcon udp 2024 system:object_r:system:s0
-portcon tcp 2024-2026 system:object_r:system:s0
+# removed portcons
+portcon udp 1024 system:object_r:system:s0
+portcon tcp 1024-1026 system:object_r:system:s0
 
 # modified portcons
-portcon udp 3024 added_user:object_r:system:s1
-portcon tcp 3024-3026 added_user:object_r:system:s1
+portcon udp 3024 removed_user:object_r:system:s0
+portcon tcp 3024-3026 removed_user:object_r:system:s0
 
 netifcon eth0 system:object_r:system:s0 system:object_r:system:s0
-netifcon added_netif system:object_r:system:s0 system:object_r:system:s0
-netifcon mod_ctx_netif added_user:object_r:system:s0 system:object_r:system:s0
-netifcon mod_pkt_netif system:object_r:system:s0 added_user:object_r:system:s0
-netifcon mod_both_netif added_user:object_r:system:s0 added_user:object_r:system:s0
+netifcon removed_netif system:object_r:system:s0 system:object_r:system:s0
+netifcon mod_ctx_netif removed_user:object_r:system:s0 system:object_r:system:s0
+netifcon mod_pkt_netif system:object_r:system:s0 removed_user:object_r:system:s0
+netifcon mod_both_netif removed_user:object_r:system:s0 removed_user:object_r:system:s0
 
 # matched nodecons
 nodecon 121.0.0.0 255.0.0.0 system:object_r:system:s0
 nodecon ff01:: ffff:ffff:ffff:fffc:: system:object_r:system:s0
 
-# added nodecons
-nodecon 124.0.0.0 255.0.0.0 added_user:object_r:system:s0
-nodecon ff04:: ffff:ffff:ffff:fffc:: added_user:object_r:system:s0
+# removed nodecons
+nodecon 122.0.0.0 255.0.0.0 removed_user:object_r:system:s0
+nodecon ff02:: ffff:ffff:ffff:fffc:: removed_user:object_r:system:s0
 
 # modified nodecons
-nodecon 123.0.0.0 255.0.0.0 modified_change_level:object_r:system:s2:c0
-nodecon ff03:: ffff:ffff:ffff:fffc:: modified_change_level:object_r:system:s2:c1
+nodecon 123.0.0.0 255.0.0.0 modified_change_level:object_r:system:s2:c1
+nodecon ff03:: ffff:ffff:ffff:fffc:: modified_change_level:object_r:system:s2:c0,c1
 
 # change netmask (add/remove)
-nodecon 125.0.0.0 255.255.0.0 system:object_r:system:s0
-nodecon ff05:: ffff:ffff:ffff:fff0:: system:object_r:system:s0
+nodecon 125.0.0.0 255.0.0.0 system:object_r:system:s0
+nodecon ff05:: ffff:ffff:ffff:fffc:: system:object_r:system:s0
 
 # matched ibpkeycons
 ibpkeycon eeee:: 0x1-0xdddd system:system:system:s0
 ibpkeycon dddd:: 0xeeee system:system:system:s0
 
 # added ibpkeycons
-ibpkeycon dead:: 0xbeef-0xdead system:system:system:s0
-ibpkeycon beef:: 0xe system:system:system:s0
 
 # removed ibpkeycons
+ibpkeycon feee:: 0xaaaa-0xbbbb system:system:system:s0
+ibpkeycon dccc:: 0xc system:system:system:s0
 
 # modified ibpkeycons
-ibpkeycon aaaa:: 0xcccc-0xdddd modified_change_level:object_r:system:s2:c0
-ibpkeycon bbbb:: 0xf modified_change_level:object_r:system:s2:c1
+ibpkeycon aaaa:: 0xcccc-0xdddd modified_change_level:object_r:system:s2:c1
+ibpkeycon bbbb:: 0xf modified_change_level:object_r:system:s2:c0,c1
 
 # matched ibendportcons
 ibendportcon match 1 system:system:system:s0
 
 # added ibendportcons
-ibendportcon add 23 system:system:system:s0
 
 # removed ibendportcons
+ibendportcon removed 7 system:system:system:s0
 
 # modified ibendportcons
-ibendportcon modified 13 modified_change_level:object_r:system:s2
+ibendportcon modified 13 modified_change_level:object_r:system:s2:c0,c1

--- a/tests/diff_left_standard.conf
+++ b/tests/diff_left_standard.conf
@@ -697,6 +697,18 @@ type dax_union_perm_source, dax_union_perm_a, dax_union_perm_c;
 type dax_union_perm_target, dax_union_perm_b;
 dontauditxperm dax_union_perm_source dax_union_perm_target:infoflow ioctl { 0x1-0x3 };
 
+attribute redundant_rule_attr;
+type redundant_rule_source_1, redundant_rule_attr;
+type redundant_rule_source_2, redundant_rule_attr;
+type redundant_rule_target_1;
+type redundant_rule_target_2;
+bool redundant_rule_bool true;
+allow redundant_rule_attr redundant_rule_target_1:infoflow low_w;
+allow redundant_rule_attr redundant_rule_target_2:infoflow med_w;
+if (redundant_rule_bool) {
+   allow redundant_rule_source_2 redundant_rule_target_2:infoflow hi_w;
+}
+
 ################################################################################
 # matching typebounds
 type match_parent;

--- a/tests/diff_right_rmisid.conf
+++ b/tests/diff_right_rmisid.conf
@@ -774,6 +774,18 @@ type dax_union_perm_source, dax_union_perm_a, dax_union_perm_c;
 type dax_union_perm_target, dax_union_perm_b;
 dontauditxperm dax_union_perm_source dax_union_perm_target:infoflow ioctl { 0x1-0x3 };
 
+attribute redundant_rule_attr;
+type redundant_rule_source_1, redundant_rule_attr;
+type redundant_rule_source_2, redundant_rule_attr;
+type redundant_rule_target_1;
+type redundant_rule_target_2;
+bool redundant_rule_bool true;
+allow redundant_rule_attr redundant_rule_target_1:infoflow low_w;
+allow redundant_rule_attr redundant_rule_target_2:infoflow med_w;
+if (redundant_rule_bool) {
+   allow redundant_rule_source_2 redundant_rule_target_2:infoflow hi_w;
+}
+
 ################################################################################
 # matching typebounds
 type match_parent;


### PR DESCRIPTION
The primary motivation for the change is to correctly handle redundant
rules. Recent changes in the SELinux toolchain added support for an
optimization that removes redundant rules from a policy. These are
conditional rules that are either already specified in unconditional
policy or rules using types that are also specified more generally
through an attribute. Since attributes are always expanded in sediff,
the second type of redundant rules are already effectively removed. But
redundant conditional rules show up as differences when a binary version
of a policy that has been optimized is compared to one that has not been.

A secondary motivation for the change is to reduce memory usage and diff
times. A modern Fedora policy cannot be diffed with a system with less than
32Gb of memory and it takes over four hours to complete.

With this change AV rules are processed by creating a data structure which
consists of nested dictionaries that store BOTH the left and the right
policies. All of the keys are interned strings to save space.

The basic structure is
  rule_db[cond_exp][block_bool][src][tgt][tclass][side]=(perms, rule)
where:
  cond_exp is a boolean expression
  block_bool is either true or false
  src is the source type
  tgt is the target type
  tclass is the target class
  side is either left or right
  perms is the set of permissions for this rule
  rule is the original unexpanded rule

A recent Refpolicy policy requires roughly 7M dictionaries for allow
and 1M dictionaries for dontaudit rules. A recent Fedora policy requires
33M dictrionaries for allow rules and 49M for dontaudit rules.

These changes improve diff times and memory usage.
Without the change
                         Time        Memory Usage
Older Fedora Policy    3 min 17 sec      4.5Gb
Recent Refpolicy       4 min 19 sec      6.0Gb
Recent Fedora Policy   4 hrs  9 min     31.9Gb

With the change
                         Time        Memory Usage
Older Fedora Policy          21 sec      2.4Gb
Recent Refpolicy             26 sec      2.9Gb
Recent Fedora Policy   3 min 41 sec     15.7Gb

Signed-off-by: James Carter <jwcart2@tycho.nsa.gov>