### PR TITLE
Remove check for permissions being a subset when deriving an expanded…

### DIFF
--- a/setools/policyrep/terule.pxi
+++ b/setools/policyrep/terule.pxi
@@ -152,8 +152,6 @@ cdef class AVRule(BaseTERule):
             raise RuleUseError("{0} is not {1} and is not in {1}".format(source, self.source))
         if target is not self.target and target not in self.target:
             raise RuleUseError("{0} is not {1} and is not in {1}".format(target, self.target))
-        if not perms <= self.perms:
-            raise RuleUseError("Permissions for derived expanded {0} rule are not a subset of the original permissions".format(self.ruletype))
 
         r = AVRule.__new__(AVRule)
         r.policy = self.policy


### PR DESCRIPTION
… rule

In class AVRUle, when deriving an expanded rule remove the check for
permissions beings a subset of the original rule.

This is not a condition that holds when attributes are expanded.

Ex/
attribute a1;
attribute a2;
type t1;
typeatrribute t1 a1, a2;
allow a1 self: c1 p1;
allow a2 self: c1 p2;

In this case the expanded rule "allow t1 t1: c1 {p1 p2};" has permissions
that are not a subset of either the allow rule with a1 or the one with a2.

Signed-off-by: James Carter <jwcart2@tycho.nsa.gov>