### PR TITLE
Support old boolean names in policy query

### DIFF
--- a/seinfo
+++ b/seinfo
@@ -125,7 +125,11 @@ try:
     if args.boolquery or args.all:
         q = setools.BoolQuery(p)
         if isinstance(args.boolquery, str):
-            q.name = args.boolquery
+            if args.policy:
+                q.name = args.boolquery
+            else:
+                # try to find substitutions for old boolean names
+                q.name = setools.policyrep.lookup_boolean_name_sub(args.boolquery)
 
         components.append(("Booleans", q, lambda x: x.statement()))
 

--- a/sesearch
+++ b/sesearch
@@ -189,7 +189,12 @@ try:
             if args.boolean_regex:
                 q.boolean = args.boolean
             else:
-                q.boolean = args.boolean.split(",")
+                if args.policy:
+                    q.boolean = args.boolean.split(",")
+                else:
+                    # try to find substitutions for old boolean names
+                    q.boolean = map(setools.policyrep.lookup_boolean_name_sub,
+                                    args.boolean.split(","))
 
         for r in sorted(q.results()):
             print(r)

--- a/setools/policyrep/selinux.pxd
+++ b/setools/policyrep/selinux.pxd
@@ -24,3 +24,4 @@ cdef extern from "<selinux/selinux.h>":
     bint selinuxfs_exists()
     const char* selinux_current_policy_path()
     const char* selinux_binary_policy_path()
+    char* selinux_boolean_sub(const char *boolean_name);

--- a/setools/policyrep/util.pxi
+++ b/setools/policyrep/util.pxi
@@ -230,3 +230,25 @@ cdef flatten_list(input_list):
             ret.append(i)
 
     return ret
+
+
+def lookup_boolean_name_sub(name):
+    """
+    Read the /etc/selinux/TYPE/booleans.subs_dist file looking
+    for a record with 'name'.
+    Return the translated name if a corresponding substitution exists,
+    otherwise return the original name.
+    """
+    cdef:
+        char *_name = selinux.selinux_boolean_sub(name)
+        str new_name = name
+
+    if _name == NULL:
+        raise MemoryError
+    # cast "char *" to "str" and free
+    try:
+        new_name = _name
+    finally:
+        free(_name)
+
+    return new_name


### PR DESCRIPTION
Translate old boolean names based on /etc/selinux/*/booleans.subs_dist
file.