### PR TITLE
RFC: Adapt setools to the new libsepol's filename transition representation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Build tests
 on: [push, pull_request]
 
 env:
-  SELINUX_USERSPACE_VERSION: libsepol-3.0
+  SELINUX_USERSPACE_VERSION: 3.2-rc1
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run SETools command line tools, the following packages are required:
 * NetworkX 2.0+
 * setuptools
 * libselinux
-* libsepol 3.0+
+* libsepol 3.2+
 
 To run SETools graphical tools, the following packages are also required:
 * PyQt5

--- a/setools/policyrep/sepol.pxd
+++ b/setools/policyrep/sepol.pxd
@@ -544,21 +544,22 @@ cdef extern from "<sepol/policydb/policydb.h>":
     ctypedef cond_bool_datum cond_bool_datum_t
 
     #
-    # filename_trans_t
+    # filename_trans_key_t
     #
-    cdef struct filename_trans:
-        uint32_t stype
+    cdef struct filename_trans_key:
         uint32_t ttype
         uint32_t tclass
         char *name
 
-    ctypedef filename_trans filename_trans_t
+    ctypedef filename_trans_key filename_trans_key_t
 
     #
     # filename_trans_datum_t
     #
     cdef struct filename_trans_datum:
+        ebitmap_t stypes
         uint32_t otype
+        filename_trans_datum *next
 
     ctypedef filename_trans_datum filename_trans_datum_t
 

--- a/tests/policyrep/selinuxpolicy.conf
+++ b/tests/policyrep/selinuxpolicy.conf
@@ -1646,9 +1646,10 @@ type_transition type91 type90:infoflow type91 "name91";
 type_transition type92 type91:infoflow type92 "name92";
 type_transition type93 type92:infoflow type93 "name93";
 type_transition type94 type93:infoflow type94 "name94";
-type_transition type95 type94:infoflow type95 "name95";
-type_transition type96 type95:infoflow type96 "name96";
-type_transition type97 type96:infoflow type97 "name97";
+
+type_transition type2 type93:infoflow type4 "name94";
+type_transition type3 type93:infoflow type4 "name94";
+type_transition type4 type93:infoflow type94 "name94";
 
 # 89 type_change
 type_change type1 type0:infoflow type1;


### PR DESCRIPTION
We are considering to merge SELinux userspace patches [1] that would cause setools to fail to build & link against libsepol. @jwcart2 already started working on abstracting a proper public API for use by setools instead of relying on libsepol's internals, but it may not be ready soon enough. This PR aims to prepare the patches that will be needed to make setools work with the new libsepol.

The first patch is intended only for testing - it directs the Travis CI to fetch userspace from a branch that contains the pending libsepol patches; the second patch does the actual conversion; and the last patch adds a few more filename transition rules to one of the test policies to exercise some corner cases in the new representation.

This PR is just an initial draft - feel free to suggest changes or different approaches. The goal is to at least have the changes ready and in mergeable state before the userspace patches are merged.

[1] https://lore.kernel.org/selinux/20200719103506.865962-1-omosnace@redhat.com/T/