### PR TITLE
Allow the specification of the self keyword in the target of an sesea…

### DIFF
--- a/sesearch
+++ b/sesearch
@@ -120,6 +120,8 @@ opts.add_argument("-rd", action="store_true", dest="default_regex",
                   help="Use regular expression matching for the default type/role.")
 opts.add_argument("-rb", action="store_true", dest="boolean_regex",
                   help="Use regular expression matching for Booleans.")
+opts.add_argument("--self", action="store_true", dest="target_self",
+                  help="Match rules where the source and target types are identical.")
 
 args = parser.parse_args()
 
@@ -131,6 +133,9 @@ if args.A:
 
 if not args.tertypes and not args.mlsrtypes and not args.rbacrtypes:
     parser.error("At least one rule type must be specified.")
+
+if args.target and args.target_self:
+    parser.error("Only one of -t and --self may be specified")
 
 if args.debug:
     logging.basicConfig(level=logging.DEBUG,
@@ -152,6 +157,7 @@ try:
                                 target=args.target,
                                 target_indirect=args.target_indirect,
                                 target_regex=args.target_regex,
+                                target_self=args.target_self,
                                 tclass_regex=args.tclass_regex,
                                 perms_equal=args.perms_equal,
                                 xperms_equal=args.xperms_equal,

--- a/setools/policyrep/selinuxpolicy.pxi
+++ b/setools/policyrep/selinuxpolicy.pxi
@@ -431,7 +431,7 @@ cdef class SELinuxPolicy:
             if t == name:
                 return t
 
-        raise InvalidType("{0} is not a valid type attribute".format(name))
+        raise InvalidType("{0} is not a valid type/attribute".format(name))
 
     def lookup_typeattr(self, name):
         """Look up a type attribute by name."""

--- a/tests/terulequery.conf
+++ b/tests/terulequery.conf
@@ -262,6 +262,20 @@ type test14;
 auditallow test14 self:infoflow7 super_both;
 dontaudit test14 self:infoflow7 super_unmapped;
 
+# test 15
+# ruletype: allow
+# source: various
+# target: self
+# class unset
+# perms: unset
+attribute test15a;
+type test15b;
+type test15c;
+type test15d, test15a;
+type test15e, test15a;
+allow test15b self:infoflow hi_w;
+allow test15c test15b:infoflow hi_w;
+allow test15a self:infoflow hi_w;
 
 # test 100
 # ruletype: unset

--- a/tests/terulequery.py
+++ b/tests/terulequery.py
@@ -183,6 +183,37 @@ class TERuleQueryTest(mixins.ValidateRule, unittest.TestCase):
         self.validate_rule(r[1], TRT.dontaudit, "test14", "test14", "infoflow7",
                            set(["super_unmapped"]))
 
+    def test_015_self_type(self):
+        """TE Rule query for self with a source type"""
+        q = TERuleQuery(self.p, source="test15b", target_self=True)
+
+        r = sorted(q.results())
+        self.assertEqual(len(r), 1)
+        self.validate_rule(r[0], TRT.allow, "test15b", "test15b", "infoflow", set(["hi_w"]))
+
+    def test_015_self_type_negative(self):
+        """TE Rule query for self with a source type, negative test"""
+        q = TERuleQuery(self.p, source="test15c", target_self=True)
+
+        r = sorted(q.results())
+        self.assertEqual(len(r), 0)
+
+    def test_015_self_attr(self):
+        """TE Rule query for self with a source attribute"""
+
+        q = TERuleQuery(self.p, source="test15a", target_self=True)
+
+        r = sorted(q.results())
+        self.assertEqual(len(r), 2)
+        self.validate_rule(r[0], TRT.allow, "test15d", "test15d", "infoflow", set(["hi_w"]))
+        self.validate_rule(r[1], TRT.allow, "test15e", "test15e", "infoflow", set(["hi_w"]))
+
+    def test_015_self_exceptions(self):
+        """TE Rule query for self exception handling"""
+        q = TERuleQuery(self.p, source="test15b", target="test15b", target_self=True)
+        with self.assertRaises(ValueError):
+            r = sorted(q.results())
+
     def test_052_perms_subset1(self):
         """TE rule query with permission subset."""
         q = TERuleQuery(self.p, perms=["super_none", "super_both"], perms_subset=True)


### PR DESCRIPTION
…rch query

This will return rules where the source type and target type are the same