### PR TITLE
TabRegistry: Add a new metaclass for generating the tab selection.

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -11,3 +11,6 @@ ignore_missing_imports = True
 
 [mypy-PyQt5.*]
 ignore_missing_imports = True
+
+[mypy-sip]
+ignore_missing_imports = True

--- a/setoolsgui/apol/__init__.py
+++ b/setoolsgui/apol/__init__.py
@@ -18,3 +18,31 @@
 #
 
 from .mainwindow import ApolMainWindow
+
+# Analysis tabs:
+from .boolquery import BoolQueryTab
+from .boundsquery import BoundsQueryTab
+from .categoryquery import CategoryQueryTab
+from .commonquery import CommonQueryTab
+from .constraintquery import ConstraintQueryTab
+from .defaultquery import DefaultQueryTab
+from .dta import DomainTransitionAnalysisTab
+from .fsusequery import FSUseQueryTab
+from .genfsconquery import GenfsconQueryTab
+from .ibendportconquery import IbendportconQueryTab
+from .ibpkeyconquery import IbpkeyconQueryTab
+from .infoflow import InfoFlowAnalysisTab
+from .initsidquery import InitialSIDQueryTab
+from .mlsrulequery import MLSRuleQueryTab
+from .netifconquery import NetifconQueryTab
+from .nodeconquery import NodeconQueryTab
+from .objclassquery import ObjClassQueryTab
+from .portconquery import PortconQueryTab
+from .rbacrulequery import RBACRuleQueryTab
+from .rolequery import RoleQueryTab
+from .sensitivityquery import SensitivityQueryTab
+from .summary import SummaryTab
+from .terulequery import TERuleQueryTab
+from .typeattrquery import TypeAttributeQueryTab
+from .typequery import TypeQueryTab
+from .userquery import UserQueryTab

--- a/setoolsgui/apol/boolquery.py
+++ b/setoolsgui/apol/boolquery.py
@@ -27,7 +27,7 @@ from setools import BoolQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..boolmodel import BooleanTableModel, boolean_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class BoolQueryTab(AnalysisTab):
 
     """Bool browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Booleans"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(BoolQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/boundsquery.py
+++ b/setoolsgui/apol/boundsquery.py
@@ -27,7 +27,7 @@ from setools import BoundsQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..boundsmodel import BoundsTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class BoundsQueryTab(AnalysisTab):
 
     """Bounds browser and query tab."""
+
+    section = AnalysisSection.Other
+    tab_title = "Bounds"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(BoundsQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/categoryquery.py
+++ b/setoolsgui/apol/categoryquery.py
@@ -27,7 +27,7 @@ from setools import CategoryQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..mlsmodel import MLSComponentTableModel, category_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class CategoryQueryTab(AnalysisTab):
 
     """Category browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "MLS Categories"
+    mlsonly = True
 
     def __init__(self, parent, policy, perm_map):
         super(CategoryQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/commonquery.py
+++ b/setoolsgui/apol/commonquery.py
@@ -27,7 +27,7 @@ from setools import CommonQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..commonmodel import CommonTableModel, common_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class CommonQueryTab(AnalysisTab):
 
     """Common browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Common Permission Sets"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(CommonQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/constraintquery.py
+++ b/setoolsgui/apol/constraintquery.py
@@ -27,7 +27,7 @@ from setools import ConstraintQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import PermListModel, SEToolsListModel, invert_list_selection
 from ..constraintmodel import ConstraintTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class ConstraintQueryTab(AnalysisTab):
 
     """A constraint query."""
+
+    section = AnalysisSection.Rules
+    tab_title = "Constraints"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(ConstraintQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/defaultquery.py
+++ b/setoolsgui/apol/defaultquery.py
@@ -28,7 +28,7 @@ from setools import DefaultQuery, DefaultValue, DefaultRangeValue
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..defaultmodel import DefaultTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_comboboxes, load_listviews, load_textedits, \
     save_checkboxes, save_comboboxes, save_listviews, save_textedits
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_comboboxes, load_listviews, load_te
 class DefaultQueryTab(AnalysisTab):
 
     """Default browser and query tab."""
+
+    section = AnalysisSection.Other
+    tab_title = "Defaults"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(DefaultQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/dta.py
+++ b/setoolsgui/apol/dta.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import QCompleter, QHeaderView, QMessageBox, QProgressDialo
 from setools import DomainTransitionAnalysis
 
 from ..logtosignal import LogHandlerToSignal
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .excludetypes import ExcludeTypes
 from .exception import TabFieldError
 from .workspace import load_checkboxes, load_spinboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_spinboxes, load_lineedits, load_tex
 class DomainTransitionAnalysisTab(AnalysisTab):
 
     """A domain transition analysis tab."""
+
+    section = AnalysisSection.Analysis
+    tab_title = "Domain Transition Analysis"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(DomainTransitionAnalysisTab, self).__init__(parent)

--- a/setoolsgui/apol/fsusequery.py
+++ b/setoolsgui/apol/fsusequery.py
@@ -26,7 +26,7 @@ from setools import FSUseQuery
 
 from ..logtosignal import LogHandlerToSignal
 from ..fsusemodel import FSUseTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class FSUseQueryTab(AnalysisTab):
 
     """A fs_use_* rule query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Fs_use_* Statements"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(FSUseQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/genfsconquery.py
+++ b/setoolsgui/apol/genfsconquery.py
@@ -26,7 +26,7 @@ from setools import GenfsconQuery
 
 from ..logtosignal import LogHandlerToSignal
 from ..genfsconmodel import GenfsconTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class GenfsconQueryTab(AnalysisTab):
 
     """A fs_use_* rule query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Genfscon Statements"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(GenfsconQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/ibendportconquery.py
+++ b/setoolsgui/apol/ibendportconquery.py
@@ -26,7 +26,7 @@ from setools import IbendportconQuery
 
 from ..logtosignal import LogHandlerToSignal
 from ..ibendportconmodel import IbendportconTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class IbendportconQueryTab(AnalysisTab):
 
     """An ibendportcon query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Infiniband Endport Contexts"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super().__init__(parent)

--- a/setoolsgui/apol/ibpkeyconquery.py
+++ b/setoolsgui/apol/ibpkeyconquery.py
@@ -26,7 +26,7 @@ from setools import IbpkeyconQuery
 
 from ..logtosignal import LogHandlerToSignal
 from ..ibpkeyconmodel import IbpkeyconTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class IbpkeyconQueryTab(AnalysisTab):
 
     """An ibpkeycon query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Infiniband Partition Key Contexts"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super().__init__(parent)

--- a/setoolsgui/apol/infoflow.py
+++ b/setoolsgui/apol/infoflow.py
@@ -30,7 +30,7 @@ from setools import InfoFlowAnalysis
 from setools.exception import UnmappedClass, UnmappedPermission
 
 from ..logtosignal import LogHandlerToSignal
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .excludetypes import ExcludeTypes
 from .permmapedit import PermissionMapEditor
@@ -41,6 +41,10 @@ from .workspace import load_checkboxes, load_spinboxes, load_lineedits, load_tex
 class InfoFlowAnalysisTab(AnalysisTab):
 
     """An information flow analysis tab."""
+
+    section = AnalysisSection.Analysis
+    tab_title = "Information Flow Analysis"
+    mlsonly = False
 
     @property
     def perm_map(self):

--- a/setoolsgui/apol/initsidquery.py
+++ b/setoolsgui/apol/initsidquery.py
@@ -26,7 +26,7 @@ from setools import InitialSIDQuery
 
 from ..logtosignal import LogHandlerToSignal
 from ..initsidmodel import InitialSIDTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class InitialSIDQueryTab(AnalysisTab):
 
     """An initial SID query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Initial SID Statements"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(InitialSIDQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/mainwindow.py
+++ b/setoolsgui/apol/mainwindow.py
@@ -30,7 +30,8 @@ from setools import __version__, PermissionMap, SELinuxPolicy
 
 from ..widget import SEToolsWidget
 from ..logtosignal import LogHandlerToSignal
-from .chooseanalysis import ChooseAnalysis, tab_map
+from .analysistab import TAB_REGISTRY
+from .chooseanalysis import ChooseAnalysis
 from .config import ApolConfig
 from .exception import TabFieldError
 from .permmapedit import PermissionMapEditor
@@ -393,7 +394,7 @@ class ApolMainWindow(SEToolsWidget, QMainWindow):
 
         if new:
             try:
-                tabclass = tab_map[settings["__tab__"]]
+                tabclass = TAB_REGISTRY[settings["__tab__"]]
             except KeyError:
                 self.log.critical("Missing analysis type in \"{0}\"".format(filename))
                 self.error_msg.critical(self, "Failed to load settings",
@@ -546,7 +547,7 @@ class ApolMainWindow(SEToolsWidget, QMainWindow):
         loading_errors = []
         for i, settings in enumerate(tab_list):
             try:
-                tabclass = tab_map[settings["__tab__"]]
+                tabclass = TAB_REGISTRY[settings["__tab__"]]
             except KeyError:
                 error_str = "Missing analysis type for tab {0}. Skipping this tab.".format(i)
                 self.log.error(error_str)

--- a/setoolsgui/apol/mlsrulequery.py
+++ b/setoolsgui/apol/mlsrulequery.py
@@ -27,7 +27,7 @@ from setools import MLSRuleQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..mlsrulemodel import MLSRuleTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class MLSRuleQueryTab(AnalysisTab):
 
     """An MLS rule query."""
+
+    section = AnalysisSection.Rules
+    tab_title = "MLS Rules"
+    mlsonly = True
 
     def __init__(self, parent, policy, perm_map):
         super(MLSRuleQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/netifconquery.py
+++ b/setoolsgui/apol/netifconquery.py
@@ -26,7 +26,7 @@ from setools import NetifconQuery
 
 from ..logtosignal import LogHandlerToSignal
 from ..netifconmodel import NetifconTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class NetifconQueryTab(AnalysisTab):
 
     """A netifcon query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Network Interface Contexts"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(NetifconQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/nodeconquery.py
+++ b/setoolsgui/apol/nodeconquery.py
@@ -27,7 +27,7 @@ from setools import NodeconQuery, NodeconIPVersion
 
 from ..logtosignal import LogHandlerToSignal
 from ..nodeconmodel import NodeconTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, load_comboboxes, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, load_com
 class NodeconQueryTab(AnalysisTab):
 
     """An nodecon query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Network Node Contexts"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(NodeconQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/objclassquery.py
+++ b/setoolsgui/apol/objclassquery.py
@@ -27,7 +27,7 @@ from setools import ObjClassQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import PermListModel, SEToolsListModel, invert_list_selection
 from ..objclassmodel import ObjClassTableModel, class_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class ObjClassQueryTab(AnalysisTab):
 
     """ObjClass browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Object Classes"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(ObjClassQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/portconquery.py
+++ b/setoolsgui/apol/portconquery.py
@@ -27,7 +27,7 @@ from setools import PortconQuery, PortconProtocol
 
 from ..logtosignal import LogHandlerToSignal
 from ..portconmodel import PortconTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, load_comboboxes, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, load_com
 class PortconQueryTab(AnalysisTab):
 
     """An portcon query."""
+
+    section = AnalysisSection.Labeling
+    tab_title = "Network Port Contexts"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(PortconQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/rbacrulequery.py
+++ b/setoolsgui/apol/rbacrulequery.py
@@ -27,7 +27,7 @@ from setools import RBACRuleQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..rbacrulemodel import RBACRuleTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class RBACRuleQueryTab(AnalysisTab):
 
     """A RBAC rule query."""
+
+    section = AnalysisSection.Rules
+    tab_title = "RBAC Rules"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(RBACRuleQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/rolequery.py
+++ b/setoolsgui/apol/rolequery.py
@@ -27,7 +27,7 @@ from setools import RoleQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..rolemodel import RoleTableModel, role_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class RoleQueryTab(AnalysisTab):
 
     """Role browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Roles"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(RoleQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/sensitivityquery.py
+++ b/setoolsgui/apol/sensitivityquery.py
@@ -27,7 +27,7 @@ from setools import SensitivityQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..mlsmodel import MLSComponentTableModel, sensitivity_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_textedits, \
 class SensitivityQueryTab(AnalysisTab):
 
     """Sensitivity browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "MLS Sensitivities"
+    mlsonly = True
 
     def __init__(self, parent, policy, perm_map):
         super(SensitivityQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/summary.py
+++ b/setoolsgui/apol/summary.py
@@ -28,7 +28,7 @@ from setools import MLSRuleQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..mlsrulemodel import MLSRuleTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_textedits, save_checkboxes, save_textedits
 
@@ -36,6 +36,10 @@ from .workspace import load_checkboxes, load_textedits, save_checkboxes, save_te
 class SummaryTab(AnalysisTab):
 
     """An SELinux policy summary."""
+
+    section = AnalysisSection.General
+    tab_title = "Summary"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(SummaryTab, self).__init__(parent)

--- a/setoolsgui/apol/terulequery.py
+++ b/setoolsgui/apol/terulequery.py
@@ -27,7 +27,7 @@ from setools import TERuleQuery, xperm_str_to_tuple_ranges
 from ..logtosignal import LogHandlerToSignal
 from ..models import PermListModel, SEToolsListModel, invert_list_selection
 from ..terulemodel import TERuleTableModel
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class TERuleQueryTab(AnalysisTab):
 
     """A Type Enforcement rule query."""
+
+    section = AnalysisSection.Rules
+    tab_title = "TE Rules"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(TERuleQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/typeattrquery.py
+++ b/setoolsgui/apol/typeattrquery.py
@@ -27,7 +27,7 @@ from setools import TypeAttributeQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..typeattrmodel import TypeAttributeTableModel, typeattr_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class TypeAttributeQueryTab(AnalysisTab):
 
     """TypeAttribute browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Type Attributes"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(TypeAttributeQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/typequery.py
+++ b/setoolsgui/apol/typequery.py
@@ -27,7 +27,7 @@ from setools import TypeQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..typemodel import TypeTableModel, type_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class TypeQueryTab(AnalysisTab):
 
     """Type browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Types"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(TypeQueryTab, self).__init__(parent)

--- a/setoolsgui/apol/userquery.py
+++ b/setoolsgui/apol/userquery.py
@@ -27,7 +27,7 @@ from setools import UserQuery
 from ..logtosignal import LogHandlerToSignal
 from ..models import SEToolsListModel, invert_list_selection
 from ..usermodel import UserTableModel, user_detail
-from .analysistab import AnalysisTab
+from .analysistab import AnalysisSection, AnalysisTab
 from .exception import TabFieldError
 from .queryupdater import QueryResultsUpdater
 from .workspace import load_checkboxes, load_lineedits, load_listviews, load_textedits, \
@@ -37,6 +37,10 @@ from .workspace import load_checkboxes, load_lineedits, load_listviews, load_tex
 class UserQueryTab(AnalysisTab):
 
     """User browser and query tab."""
+
+    section = AnalysisSection.Components
+    tab_title = "Users"
+    mlsonly = False
 
     def __init__(self, parent, policy, perm_map):
         super(UserQueryTab, self).__init__(parent)


### PR DESCRIPTION
The ChooseAnalysis dialog lists the analysis tabs so the user can select
them.  Create a new metaclass so the listing of tabs, grouping in the menu,
and the invocation of the tab's class is automatic.  This requires section,
tab_title, and mlsonly class attributes.

Signed-off-by: Chris PeBenito <pebenito@ieee.org>