### PR TITLE
apol: Suppress RuntimeErrors in analysis tab destructors.

### DIFF
--- a/setoolsgui/apol/boolquery.py
+++ b/setoolsgui/apol/boolquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class BoolQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.boolquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/boundsquery.py
+++ b/setoolsgui/apol/boundsquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class BoundsQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.boundsquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/categoryquery.py
+++ b/setoolsgui/apol/categoryquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class CategoryQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.categoryquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/commonquery.py
+++ b/setoolsgui/apol/commonquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class CommonQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.commonquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/constraintquery.py
+++ b/setoolsgui/apol/constraintquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class ConstraintQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.constraintquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/defaultquery.py
+++ b/setoolsgui/apol/defaultquery.py
@@ -19,6 +19,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class DefaultQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.defaultquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/dta.py
+++ b/setoolsgui/apol/dta.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import pyqtSignal, Qt, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -47,8 +48,10 @@ class DomainTransitionAnalysisTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.dta").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/fsusequery.py
+++ b/setoolsgui/apol/fsusequery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -45,8 +46,10 @@ class FSUseQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.fsusequery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/genfsconquery.py
+++ b/setoolsgui/apol/genfsconquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -45,8 +46,10 @@ class GenfsconQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.genfsconquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/ibendportconquery.py
+++ b/setoolsgui/apol/ibendportconquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -45,8 +46,10 @@ class IbendportconQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.ibendportconquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/ibpkeyconquery.py
+++ b/setoolsgui/apol/ibpkeyconquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -45,8 +46,10 @@ class IbpkeyconQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.ibpkeyconquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/infoflow.py
+++ b/setoolsgui/apol/infoflow.py
@@ -72,8 +72,10 @@ class InfoFlowAnalysisTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.infoflow").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/initsidquery.py
+++ b/setoolsgui/apol/initsidquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -45,8 +46,10 @@ class InitialSIDQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.initsidquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/mlsrulequery.py
+++ b/setoolsgui/apol/mlsrulequery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class MLSRuleQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.mlsrulequery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/netifconquery.py
+++ b/setoolsgui/apol/netifconquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -45,8 +46,10 @@ class NetifconQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.netifconquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/nodeconquery.py
+++ b/setoolsgui/apol/nodeconquery.py
@@ -19,6 +19,7 @@
 #
 import sys
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class NodeconQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.nodeconquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/objclassquery.py
+++ b/setoolsgui/apol/objclassquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class ObjClassQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.objclassquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/portconquery.py
+++ b/setoolsgui/apol/portconquery.py
@@ -19,6 +19,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class PortconQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.portconquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/rbacrulequery.py
+++ b/setoolsgui/apol/rbacrulequery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class RBACRuleQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.rbacrulequery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/rolequery.py
+++ b/setoolsgui/apol/rolequery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class RoleQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.rolequery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/sensitivityquery.py
+++ b/setoolsgui/apol/sensitivityquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class SensitivityQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.sensitivityquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/terulequery.py
+++ b/setoolsgui/apol/terulequery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class TERuleQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.terulequery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/typeattrquery.py
+++ b/setoolsgui/apol/typeattrquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class TypeAttributeQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.typeattrquery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/typequery.py
+++ b/setoolsgui/apol/typequery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class TypeQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.typequery").removeHandler(self.handler)
 
     def setupUi(self):

--- a/setoolsgui/apol/userquery.py
+++ b/setoolsgui/apol/userquery.py
@@ -18,6 +18,7 @@
 #
 
 import logging
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt, QSortFilterProxyModel, QStringListModel, QThread
 from PyQt5.QtGui import QPalette, QTextCursor
@@ -46,8 +47,10 @@ class UserQueryTab(AnalysisTab):
         self.setupUi()
 
     def __del__(self):
-        self.thread.quit()
-        self.thread.wait(5000)
+        with suppress(RuntimeError):
+            self.thread.quit()
+            self.thread.wait(5000)
+
         logging.getLogger("setools.userquery").removeHandler(self.handler)
 
     def setupUi(self):


### PR DESCRIPTION
Suppress errors like this:

Exception ignored in: <function DomainTransitionAnalysisTab.__del__ at 0x7fcb4e93c1f0>
Traceback (most recent call last):
  File "/home/pebenito/projects/setools/setoolsgui/apol/dta.py", line 54, in __del__
    self.thread.quit()
RuntimeError: wrapped C/C++ object of type ResultsUpdater has been deleted
Exception ignored in: <function ResultsUpdater.__del__ at 0x7fcb4e943550>
Traceback (most recent call last):
  File "/home/pebenito/projects/setools/setoolsgui/apol/dta.py", line 449, in __del__
    self.wait()
RuntimeError: wrapped C/C++ object of type ResultsUpdater has been deleted
Exception ignored in: <function BrowserUpdater.__del__ at 0x7fcb4e943820>
Traceback (most recent call last):
  File "/home/pebenito/projects/setools/setoolsgui/apol/dta.py", line 538, in __del__
    self.wait()
RuntimeError: wrapped C/C++ object of type BrowserUpdater has been deleted

Signed-off-by: Chris PeBenito <pebenito@ieee.org>