### PR TITLE
ConfigSetDescriptor: Fix parsing of multiline values.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+  * Fix bug in sechecker parsing of multiline values.
+
 *setools-4.4.0 (5 Mar 2021)
 
   * Updated policy representation to handle policydb version 33, compressed

--- a/setools/checker/descriptors.py
+++ b/setools/checker/descriptors.py
@@ -16,6 +16,7 @@
 # License along with SETools.  If not, see
 # <http://www.gnu.org/licenses/>.
 #
+import re
 from typing import Callable, Union
 
 from ..exception import InvalidCheckValue
@@ -90,7 +91,7 @@ class ConfigSetDescriptor(CriteriaDescriptor):
             else:
                 lookup = getattr(obj.policy, self.lookup_function)
             ret = set()
-            for item in (i for i in value.split(" ") if i):
+            for item in (i for i in re.split(r"\s", value) if i):
                 try:
                     o = lookup(item)
                     if self.expand:

--- a/tests/checker/checker-valid.ini
+++ b/tests/checker/checker-valid.ini
@@ -7,7 +7,8 @@ attr = empty_source_attr
 desc = read only executables test
 check_type = ro_execs
 exempt_exec_domain = unconfined
-exempt_write_domain = domain1 domain2 unconfined
+exempt_write_domain = domain1
+    domain2 unconfined
 
 [assertte]
 check_type = assert_te


### PR DESCRIPTION
The parsing did not correctly handle newline and tab characters.

Add a multiline value in the sechecker test config file to make sure this
case is tested.
