### PR TITLE
Update permission map

### DIFF
--- a/setools/perm_map
+++ b/setools/perm_map
@@ -29,7 +29,7 @@
 # Number of object classes.
 129
 
-class netlink_audit_socket 28
+class netlink_audit_socket 26
          nlmsg_relay         w        10
      nlmsg_tty_audit         w        10
       nlmsg_readpriv         r        10
@@ -44,8 +44,6 @@ class netlink_audit_socket 28
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -59,11 +57,8 @@ class netlink_audit_socket 28
               listen         r         1
                  map         n         1
 
-class tcp_socket 28
-          acceptfrom         r         1
-           connectto         w         1
+class tcp_socket 23
            node_bind         n         1
-             newconn         w         1
         name_connect         w         1
               append         w        10
                 bind         w         1
@@ -74,8 +69,6 @@ class tcp_socket 28
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -121,7 +114,7 @@ class db_procedure 9
              setattr         w         7
            relabelto         w         1
 
-class dir 31
+class dir 30
                rmdir         b         1
         audit_access         r         1
          remove_name         w         1
@@ -146,7 +139,6 @@ class dir 31
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -157,7 +149,7 @@ class dir 31
 class peer 1
                 recv         r        10
 
-class blk_file 26
+class blk_file 25
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -177,7 +169,6 @@ class blk_file 26
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -185,7 +176,7 @@ class blk_file 26
      watch_with_perm         r         3
          watch_reads         r         3
 
-class chr_file 26
+class chr_file 25
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -205,7 +196,6 @@ class chr_file 26
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -250,7 +240,7 @@ class ipc 9
                 read         r        10
           unix_write         w         3
 
-class lnk_file 26
+class lnk_file 25
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -270,7 +260,6 @@ class lnk_file 26
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -331,7 +320,7 @@ class packet 7
            relabelto         w         3
              flow_in         r        10
 
-class socket 23
+class socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -341,8 +330,6 @@ class socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -356,7 +343,7 @@ class socket 23
               listen         r         1
                  map         n         1
 
-class fifo_file 26
+class fifo_file 25
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -376,7 +363,6 @@ class fifo_file 26
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -384,7 +370,7 @@ class fifo_file 26
      watch_with_perm         r         3
          watch_reads         r         3
 
-class file 28
+class file 27
         audit_access         r         1
           entrypoint         r         1
              execmod         n         1
@@ -406,7 +392,6 @@ class file 28
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -414,16 +399,7 @@ class file 28
      watch_with_perm         r         3
          watch_reads         r         3
 
-class node 11
-          rawip_recv         r        10
-            tcp_recv         r        10
-            udp_recv         r        10
-          rawip_send         w        10
-            tcp_send         w        10
-            udp_send         w        10
-           dccp_recv         r        10
-           dccp_send         w        10
-        enforce_dest         n         1
+class node 2
               sendto         w        10
             recvfrom         r        10
 
@@ -453,7 +429,7 @@ class db_view 7
              setattr         w         5
            relabelto         w         1
 
-class netlink_nflog_socket 23
+class netlink_nflog_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -463,8 +439,6 @@ class netlink_nflog_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -487,7 +461,7 @@ class key 7
                 read         r        10
               search         r         5
 
-class netlink_tcpdiag_socket 25
+class netlink_tcpdiag_socket 23
          nlmsg_write         w        10
           nlmsg_read         r        10
               append         w        10
@@ -499,8 +473,6 @@ class netlink_tcpdiag_socket 25
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -514,10 +486,8 @@ class netlink_tcpdiag_socket 25
               listen         r         1
                  map         n         1
 
-class unix_stream_socket 26
-          acceptfrom         r         1
+class unix_stream_socket 22
            connectto         w         1
-             newconn         w         1
               append         w        10
                 bind         w         1
              connect         w         1
@@ -527,8 +497,6 @@ class unix_stream_socket 26
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -573,7 +541,7 @@ class kernel_service 2
      create_files_as         n         1
      use_as_override         n         1
 
-class netlink_route_socket 25
+class netlink_route_socket 23
          nlmsg_write         w        10
           nlmsg_read         r        10
               append         w        10
@@ -585,8 +553,6 @@ class netlink_route_socket 25
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -631,7 +597,7 @@ class x_resource 2
                write         w        10
                 read         r        10
 
-class netlink_selinux_socket 23
+class netlink_selinux_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -641,8 +607,6 @@ class netlink_selinux_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -690,7 +654,7 @@ class capability 32
         sys_resource         n         1
                chown         n         1
 
-class netlink_ip6fw_socket 25
+class netlink_ip6fw_socket 23
          nlmsg_write         w        10
           nlmsg_read         r        10
               append         w        10
@@ -702,8 +666,6 @@ class netlink_ip6fw_socket 25
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -717,7 +679,7 @@ class netlink_ip6fw_socket 25
               listen         r         1
                  map         n         1
 
-class dccp_socket 25
+class dccp_socket 23
            node_bind         n         1
         name_connect         w        10
               append         w        10
@@ -729,8 +691,6 @@ class dccp_socket 25
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -744,7 +704,7 @@ class dccp_socket 25
               listen         r         1
                  map         n         1
 
-class netlink_firewall_socket 25
+class netlink_firewall_socket 23
          nlmsg_write         w        10
           nlmsg_read         r        10
               append         w        10
@@ -756,8 +716,6 @@ class netlink_firewall_socket 25
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -771,7 +729,7 @@ class netlink_firewall_socket 25
               listen         r         1
                  map         n         1
 
-class sock_file 26
+class sock_file 25
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -791,7 +749,6 @@ class sock_file 26
            relabelto         w        10
              mounton         b         1
              quotaon         b         1
-              swapon         b         1
                  map         n         1
                watch         r         3
          watch_mount         r         3
@@ -799,7 +756,7 @@ class sock_file 26
      watch_with_perm         r         3
          watch_reads         r         3
 
-class unix_dgram_socket 23
+class unix_dgram_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -809,8 +766,6 @@ class unix_dgram_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -824,7 +779,7 @@ class unix_dgram_socket 23
               listen         r         1
                  map         n         1
 
-class netlink_kobject_uevent_socket 23
+class netlink_kobject_uevent_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -834,8 +789,6 @@ class netlink_kobject_uevent_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -861,11 +814,10 @@ class db_blob 10
              setattr         w         7
            relabelto         w         1
 
-class filesystem 11
+class filesystem 10
            associate         n         1
             quotaget         r         1
          relabelfrom         r        10
-          transition         w         1
              getattr         r         1
             quotamod         w         1
                mount         w         1
@@ -874,7 +826,7 @@ class filesystem 11
            relabelto         w        10
                watch         r         3
 
-class netlink_xfrm_socket 25
+class netlink_xfrm_socket 23
          nlmsg_write         w        10
           nlmsg_read         r        10
               append         w        10
@@ -886,8 +838,6 @@ class netlink_xfrm_socket 25
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -933,7 +883,7 @@ class db_schema 9
              setattr         w         5
            relabelto         r         1
 
-class netlink_dnrt_socket 23
+class netlink_dnrt_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -943,8 +893,6 @@ class netlink_dnrt_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1006,7 +954,7 @@ class x_font 6
              getattr         r         7
                  use         r         1
 
-class key_socket 23
+class key_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1016,8 +964,6 @@ class key_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1031,19 +977,11 @@ class key_socket 23
               listen         r         1
                  map         n         1
 
-class netif 10
-          rawip_recv         r        10
-            tcp_recv         r        10
-            udp_recv         r        10
-          rawip_send         w        10
+class netif 2
               egress         w        10
              ingress         r        10
-            tcp_send         w        10
-            udp_send         w        10
-           dccp_recv         r        10
-           dccp_send         w        10
 
-class packet_socket 23
+class packet_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1053,8 +991,6 @@ class packet_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1075,7 +1011,7 @@ class msg 2
                 send         w        10
              receive         r        10
 
-class tun_socket 24
+class tun_socket 22
         attach_queue         w         5
               append         w        10
                 bind         w         1
@@ -1086,8 +1022,6 @@ class tun_socket 24
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1101,7 +1035,7 @@ class tun_socket 24
               listen         r         1
                  map         n         1
 
-class udp_socket 24
+class udp_socket 22
            node_bind         n         1
               append         w        10
                 bind         w         1
@@ -1112,8 +1046,6 @@ class udp_socket 24
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1127,7 +1059,7 @@ class udp_socket 24
               listen         r         1
                  map         n         1
 
-class appletalk_socket 23
+class appletalk_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1137,8 +1069,6 @@ class appletalk_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         1
              setattr         w         1
               accept         r         1
@@ -1174,7 +1104,7 @@ class x_screen 8
        saver_getattr         r         7
        saver_setattr         w         7
 
-class rawip_socket 24
+class rawip_socket 22
            node_bind         n         1
               append         w        10
                 bind         w         1
@@ -1185,8 +1115,6 @@ class rawip_socket 24
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         1
              setattr         w         1
               accept         r         1
@@ -1228,7 +1156,7 @@ class db_column 9
              setattr         w         7
            relabelto         w         1
 
-class netlink_socket 23
+class netlink_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1238,8 +1166,6 @@ class netlink_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1364,7 +1290,7 @@ class binder 4
      set_context_mgr         w         1
          impersonate         n         1
 
-class netlink_connector_socket 23
+class netlink_connector_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1374,8 +1300,6 @@ class netlink_connector_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1389,7 +1313,7 @@ class netlink_connector_socket 23
               listen         r         1
                  map         n         1
 
-class netlink_netfilter_socket 23
+class netlink_netfilter_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1399,8 +1323,6 @@ class netlink_netfilter_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1414,7 +1336,7 @@ class netlink_netfilter_socket 23
               listen         r         1
                  map         n         1
 
-class netlink_iscsi_socket 23
+class netlink_iscsi_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1424,8 +1346,6 @@ class netlink_iscsi_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1448,7 +1368,7 @@ class db_exception 7
            relabelto         w         1
                  use         r         1
 
-class netlink_rdma_socket 23
+class netlink_rdma_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1458,8 +1378,6 @@ class netlink_rdma_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1473,7 +1391,7 @@ class netlink_rdma_socket 23
               listen         r         1
                  map         n         1
 
-class netlink_generic_socket 23
+class netlink_generic_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1483,8 +1401,6 @@ class netlink_generic_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1498,7 +1414,7 @@ class netlink_generic_socket 23
               listen         r         1
                  map         n         1
 
-class netlink_scsitransport_socket 23
+class netlink_scsitransport_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1508,8 +1424,6 @@ class netlink_scsitransport_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1531,7 +1445,7 @@ class service 6
               reload         w         1
                 stop         w         1
 
-class netlink_crypto_socket 23
+class netlink_crypto_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1541,8 +1455,6 @@ class netlink_crypto_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1565,7 +1477,7 @@ class db_datatype 7
            relabelto         w         1
                  use         r         1
 
-class netlink_fib_lookup_socket 23
+class netlink_fib_lookup_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1575,8 +1487,6 @@ class netlink_fib_lookup_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1632,7 +1542,7 @@ class cap2_userns 6
           wake_alarm         n         1
           audit_read         n         1
 
-class ax25_socket 23
+class ax25_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1642,8 +1552,6 @@ class ax25_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1657,7 +1565,7 @@ class ax25_socket 23
               listen         r         1
                  map         n         1
 
-class ipx_socket 23
+class ipx_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1667,8 +1575,6 @@ class ipx_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1682,7 +1588,7 @@ class ipx_socket 23
               listen         r         1
                  map         n         1
 
-class netrom_socket 23
+class netrom_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1692,8 +1598,6 @@ class netrom_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1707,7 +1611,7 @@ class netrom_socket 23
               listen         r         1
                  map         n         1
 
-class x25_socket 23
+class x25_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1717,8 +1621,6 @@ class x25_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1732,7 +1634,7 @@ class x25_socket 23
               listen         r         1
                  map         n         1
 
-class rose_socket 23
+class rose_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1742,8 +1644,6 @@ class rose_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1757,7 +1657,7 @@ class rose_socket 23
               listen         r         1
                  map         n         1
 
-class decnet_socket 23
+class decnet_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1767,8 +1667,6 @@ class decnet_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1782,7 +1680,7 @@ class decnet_socket 23
               listen         r         1
                  map         n         1
 
-class atmsvc_socket 23
+class atmsvc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1792,8 +1690,6 @@ class atmsvc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1807,7 +1703,7 @@ class atmsvc_socket 23
               listen         r         1
                  map         n         1
 
-class rds_socket 23
+class rds_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1817,8 +1713,6 @@ class rds_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1832,7 +1726,7 @@ class rds_socket 23
               listen         r         1
                  map         n         1
 
-class irda_socket 23
+class irda_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1842,8 +1736,6 @@ class irda_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1857,7 +1749,7 @@ class irda_socket 23
               listen         r         1
                  map         n         1
 
-class pppox_socket 23
+class pppox_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1867,8 +1759,6 @@ class pppox_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1882,7 +1772,7 @@ class pppox_socket 23
               listen         r         1
                  map         n         1
 
-class llc_socket 23
+class llc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1892,8 +1782,6 @@ class llc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1907,7 +1795,7 @@ class llc_socket 23
               listen         r         1
                  map         n         1
 
-class can_socket 23
+class can_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1917,8 +1805,6 @@ class can_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1932,7 +1818,7 @@ class can_socket 23
               listen         r         1
                  map         n         1
 
-class tipc_socket 23
+class tipc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1942,8 +1828,6 @@ class tipc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1957,7 +1841,7 @@ class tipc_socket 23
               listen         r         1
                  map         n         1
 
-class bluetooth_socket 23
+class bluetooth_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1967,8 +1851,6 @@ class bluetooth_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -1982,7 +1864,7 @@ class bluetooth_socket 23
               listen         r         1
                  map         n         1
 
-class iucv_socket 23
+class iucv_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -1992,8 +1874,6 @@ class iucv_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2007,7 +1887,7 @@ class iucv_socket 23
               listen         r         1
                  map         n         1
 
-class rxrpc_socket 23
+class rxrpc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2017,8 +1897,6 @@ class rxrpc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2032,7 +1910,7 @@ class rxrpc_socket 23
               listen         r         1
                  map         n         1
 
-class isdn_socket 23
+class isdn_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2042,8 +1920,6 @@ class isdn_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2057,7 +1933,7 @@ class isdn_socket 23
               listen         r         1
                  map         n         1
 
-class phonet_socket 23
+class phonet_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2067,8 +1943,6 @@ class phonet_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2082,7 +1956,7 @@ class phonet_socket 23
               listen         r         1
                  map         n         1
 
-class ieee802154_socket 23
+class ieee802154_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2092,8 +1966,6 @@ class ieee802154_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2107,7 +1979,7 @@ class ieee802154_socket 23
               listen         r         1
                  map         n         1
 
-class caif_socket 23
+class caif_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2117,8 +1989,6 @@ class caif_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2132,7 +2002,7 @@ class caif_socket 23
               listen         r         1
                  map         n         1
 
-class alg_socket 23
+class alg_socket 21
               append         w        10
                 bind         w         1
              connect         n         1
@@ -2142,8 +2012,6 @@ class alg_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2157,7 +2025,7 @@ class alg_socket 23
               listen         r         1
                  map         n         1
 
-class nfc_socket 23
+class nfc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2167,8 +2035,6 @@ class nfc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2182,7 +2048,7 @@ class nfc_socket 23
               listen         r         1
                  map         n         1
 
-class vsock_socket 23
+class vsock_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2192,8 +2058,6 @@ class vsock_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2207,7 +2071,7 @@ class vsock_socket 23
               listen         r         1
                  map         n         1
 
-class kcm_socket 23
+class kcm_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2217,8 +2081,6 @@ class kcm_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2232,7 +2094,7 @@ class kcm_socket 23
               listen         r         1
                  map         n         1
 
-class qipcrtr_socket 23
+class qipcrtr_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2242,8 +2104,6 @@ class qipcrtr_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2257,7 +2117,7 @@ class qipcrtr_socket 23
               listen         r         1
                  map         n         1
 
-class smc_socket 23
+class smc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2267,8 +2127,6 @@ class smc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2282,7 +2140,7 @@ class smc_socket 23
               listen         r         1
                  map         n         1
 
-class sctp_socket 26
+class sctp_socket 24
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2292,8 +2150,6 @@ class sctp_socket 26
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2310,7 +2166,7 @@ class sctp_socket 26
          association         w         1
         name_connect         w        10
 
-class atmpvc_socket 23
+class atmpvc_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2320,8 +2176,6 @@ class atmpvc_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2335,7 +2189,7 @@ class atmpvc_socket 23
               listen         r         1
                  map         n         1
 
-class icmp_socket 24
+class icmp_socket 22
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2345,8 +2199,6 @@ class icmp_socket 24
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1
@@ -2378,7 +2230,7 @@ class infiniband_endport 1
 class infiniband_pkey 1
               access         b        10
 
-class xdp_socket 23
+class xdp_socket 21
               append         w        10
                 bind         w         1
              connect         w         1
@@ -2388,8 +2240,6 @@ class xdp_socket 23
                ioctl         n         1
            name_bind         n         1
               sendto         w        10
-            recv_msg         r        10
-            send_msg         w        10
              getattr         r         7
              setattr         w         7
               accept         r         1

--- a/setools/perm_map
+++ b/setools/perm_map
@@ -121,7 +121,7 @@ class db_procedure 9
              setattr         w         7
            relabelto         w         1
 
-class dir 26
+class dir 31
                rmdir         b         1
         audit_access         r         1
          remove_name         w         1
@@ -148,11 +148,16 @@ class dir 26
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
 class peer 1
                 recv         r        10
 
-class blk_file 21
+class blk_file 26
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -174,12 +179,15 @@ class blk_file 21
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
-class chr_file 23
+class chr_file 26
         audit_access         r         1
-          entrypoint         r         1
              execmod         n         1
-    execute_no_trans         r         1
                 open         n         1
               append         w        10
               create         w         1
@@ -199,6 +207,11 @@ class chr_file 23
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
 class db_table 11
               select         n         1
@@ -237,7 +250,7 @@ class ipc 9
                 read         r        10
           unix_write         w         3
 
-class lnk_file 21
+class lnk_file 26
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -259,6 +272,11 @@ class lnk_file 21
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
 class process 31
               getcap         r         3
@@ -338,7 +356,7 @@ class socket 23
               listen         r         1
                  map         n         1
 
-class fifo_file 21
+class fifo_file 26
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -360,8 +378,13 @@ class fifo_file 21
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
-class file 23
+class file 28
         audit_access         r         1
           entrypoint         r         1
              execmod         n         1
@@ -385,6 +408,11 @@ class file 23
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
 class node 11
           rawip_recv         r        10
@@ -743,7 +771,7 @@ class netlink_firewall_socket 25
               listen         r         1
                  map         n         1
 
-class sock_file 21
+class sock_file 26
         audit_access         r         1
              execmod         n         1
                 open         n         1
@@ -765,6 +793,11 @@ class sock_file 21
              quotaon         b         1
               swapon         b         1
                  map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3
 
 class unix_dgram_socket 23
               append         w        10
@@ -828,7 +861,7 @@ class db_blob 10
              setattr         w         7
            relabelto         w         1
 
-class filesystem 10
+class filesystem 11
            associate         n         1
             quotaget         r         1
          relabelfrom         r        10
@@ -839,6 +872,7 @@ class filesystem 10
              remount         w         1
              unmount         w         1
            relabelto         w        10
+               watch         r         3
 
 class netlink_xfrm_socket 25
          nlmsg_write         w        10
@@ -2368,3 +2402,42 @@ class xdp_socket 23
            relabelto         w        10
               listen         r         1
                  map         n         1
+
+class lockdown 2
+           integrity         b         1
+     confidentiality         r         1
+
+class perf_event 6
+                open         r         1
+                 cpu         r         5
+              kernel         r         5
+          tracepoint         r         5
+                read         r         1
+               write         w         1
+
+class anon_inode 25
+        audit_access         r         1
+             execmod         n         1
+                open         n         1
+              append         w        10
+              create         w         1
+             execute         r         1
+               write         w        10
+         relabelfrom         r        10
+                link         w         1
+              unlink         w         1
+               ioctl         n         1
+             getattr         r         7
+             setattr         w         7
+                read         r        10
+              rename         w         5
+                lock         n         1
+           relabelto         w        10
+             mounton         b         1
+             quotaon         b         1
+                 map         n         1
+               watch         r         3
+         watch_mount         r         3
+            watch_sb         r         3
+     watch_with_perm         r         3
+         watch_reads         r         3


### PR DESCRIPTION
Add watch permissions, added in https://github.com/SELinuxProject/selinux-kernel/commit/ac5656d8a4cdd93cd2c74355ed12e5617817e0e7

Add `perf_event` class, added in https://github.com/SELinuxProject/selinux-kernel/commit/da97e18458fb42d7c00fac5fd1c56a3896ec666e

Add `lockdown` class, added in https://github.com/SELinuxProject/selinux-kernel/commit/59438b46471ae6cdfb761afc8c9beaf1e428a331

Add `anon_inode` class, added in https://github.com/SELinuxProject/selinux-kernel/commit/29cd6591ab6fee3125ea5c1bf350f5013bc615e1

Weight removed permission with value 10, see https://github.com/SELinuxProject/selinux-kernel/commit/42a9699a9fa179c0054ea3cf5ad3cc67104a6162

Drop inexistent `permissions execute_no_trans` and `entrypoint` from `chr_file`

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>