### PR TITLE
Minor improvements to sedta and seinfoflow

### DIFF
--- a/sedta
+++ b/sedta
@@ -26,6 +26,8 @@ import setools
 
 
 def print_transition(trans: setools.DomainTransition) -> None:
+    print()
+
     if trans.transition:
         print("Domain transition rule(s):")
         for t in trans.transition:
@@ -77,6 +79,7 @@ parser.add_argument("--version", action="version", version=setools.__version__)
 parser.add_argument("-p", "--policy", help="Path to SELinux policy to analyze.")
 parser.add_argument("-s", "--source", help="Source type of the analysis.", required=True)
 parser.add_argument("-t", "--target", help="Target type of the analysis.")
+parser.add_argument("--full", help="Print rule lists for transitions.", action="store_true")
 parser.add_argument("--stats", action="store_true",
                     help="Display statistics at the end of the analysis.")
 parser.add_argument("-v", "--verbose", action="store_true",
@@ -128,26 +131,32 @@ try:
 
             for stepnum, step in enumerate(path, start=1):
 
-                print("Step {0}: {1} -> {2}\n".format(stepnum, step.source, step.target))
-                print_transition(step)
+                print("Step {0}: {1} -> {2}".format(stepnum, step.source, step.target))
+
+                if args.full:
+                    print_transition(step)
 
             if args.limit_trans and i >= args.limit_trans:
                 break
 
-        print(i, "domain transition path(s) found.")
+            print()
+
+        print("\n{} domain transition path(s) found.".format(i))
 
     else:  # single transition
         transitions = g.transitions(args.source)
 
         i = 0
         for i, step in enumerate(transitions, start=1):
-            print("Transition {0}: {1} -> {2}\n".format(i, step.source, step.target))
-            print_transition(step)
+            print("Transition {0}: {1} -> {2}".format(i, step.source, step.target))
+
+            if args.full:
+                print_transition(step)
 
             if args.limit_trans and i >= args.limit_trans:
                 break
 
-        print(i, "domain transition(s) found.")
+        print("\n{} domain transition(s) found.".format(i))
 
     if args.stats:
         print("\nGraph statistics:")

--- a/seinfoflow
+++ b/seinfoflow
@@ -41,8 +41,8 @@ parser.add_argument("--debug", action="store_true", dest="debug", help="Enable d
 settings = parser.add_argument_group("Analysis settings")
 settings.add_argument("-p", "--policy",
                       help="Path to SELinux policy to analyze.")
-settings.add_argument("-m", "--map", required=True,
-                      help="Path to permission map file.")
+settings.add_argument("-m", "--map",
+                      help="Path to alternative permission map file.")
 settings.add_argument("-s", "--source", required=True,
                       help="Source type of the analysis.")
 settings.add_argument("-t", "--target", default="",

--- a/seinfoflow
+++ b/seinfoflow
@@ -29,6 +29,8 @@ signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 parser = argparse.ArgumentParser(
     description="SELinux policy information flow analysis tool.",
     epilog="If no analysis is selected, all information flow out of the source will be printed.")
+parser.add_argument("--full", help="Print full rule lists for information flows.",
+                    action="store_true")
 parser.add_argument("--version", action="version", version=setools.__version__)
 parser.add_argument("--stats", action="store_true",
                     help="Display statistics at the end of the analysis.")
@@ -117,10 +119,11 @@ try:
             for stepnum, step in enumerate(path, start=1):
                 print("  Step {0}: {1} -> {2}".format(stepnum, step.source, step.target))
 
-                for rule in sorted(step.rules):
-                    print("   ", rule)
+                if args.full:
+                    for rule in sorted(step.rules):
+                        print("   ", rule)
 
-                print()
+                    print()
 
             if args.limit_flows and flownum >= args.limit_flows:
                 break
@@ -131,15 +134,17 @@ try:
         flownum = 0
         for flownum, flow in enumerate(g.infoflows(args.source), start=1):
             print("Flow {0}: {1} -> {2}".format(flownum, flow.source, flow.target))
-            for rule in sorted(flow.rules):
-                print("   ", rule)
 
-            print()
+            if args.full:
+                for rule in sorted(flow.rules):
+                    print("   ", rule)
+
+                print()
 
             if args.limit_flows and flownum >= args.limit_flows:
                 break
 
-    print(flownum, "information flow(s) found.")
+    print("\n{} information flow(s) found.".format(flownum))
 
     if args.stats:
         print("\nGraph statistics:")


### PR DESCRIPTION
* Make a brief output for sedta and seinfoflow. This is the default. Use `--full` to get the full ouptput.
* Make the `-m` option of seinfoflow optional.