### PR TITLE
Update text of man page for -ep flag

### DIFF
--- a/man/sesearch.1
+++ b/man/sesearch.1
@@ -83,7 +83,7 @@ A matching rule must have the specified target attribute/type/role explicitly, i
 .IP "-eb"
 A matching rule must have all specified Booleans, instead of matching any of the specified Boolean.
 .IP "-ep"
-A matching rule must have all specified permissions, instead of matching any of the specified permission.
+A matching rule must have exactly the specified permissions, instead of matching any of the specified permission.
 .IP "-rs"
 Use regular expression for matching the source type/role.
 .IP "-rt"


### PR DESCRIPTION
The old text does not match the behavior observed in practice or the
description in the --help flag