### PR TITLE
Add -Sp argument to sesearch to serve as front end for perms_subset

### DIFF
--- a/man/sesearch.1
+++ b/man/sesearch.1
@@ -84,6 +84,8 @@ A matching rule must have the specified target attribute/type/role explicitly, i
 A matching rule must have all specified Booleans, instead of matching any of the specified Boolean.
 .IP "-ep"
 A matching rule must have exactly the specified permissions, instead of matching any of the specified permission.
+.IP "-Sp"
+A matching rule must have permissions where are a superset of the specified permissions, instead of matching any of the permissions.
 .IP "-rs"
 Use regular expression for matching the source type/role.
 .IP "-rt"

--- a/sesearch
+++ b/sesearch
@@ -93,6 +93,9 @@ opts.add_argument("-ep", action="store_true", dest="perms_equal",
 opts.add_argument("-ex", action="store_true", dest="xperms_equal",
                   help="Match extended permission set exactly instead of matching any listed "
                   "permission.")
+opts.add_argument("-Sp", action="store_true", dest="perms_subset",
+                  help="Match rules where the listed permissions are a subset of the rule "
+                  "permissions.")
 opts.add_argument("-ds", action="store_false", dest="source_indirect",
                   help="Match source attributes directly instead of matching member types/roles.")
 opts.add_argument("-dt", action="store_false", dest="target_indirect",
@@ -141,6 +144,7 @@ try:
                                    target_regex=args.target_regex,
                                    tclass_regex=args.tclass_regex,
                                    perms_equal=args.perms_equal,
+                                   perms_subset=args.perms_subset,
                                    xperms_equal=args.xperms_equal,
                                    default=args.default,
                                    default_regex=args.default_regex,


### PR DESCRIPTION
The perms_subset rule search flag matches rules where the searched perms
are a subset of the rule perms.  This flag is currently only exposed via
apol, and this commit exposes it via sesearch

Signed-off-by: Daniel Burgener <dburgener@linux.microsoft.com>