### PR TITLE
Add pyproject.toml to fix Cython dependency issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "Cython>=0.27"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Attempting to install the `setools` package using `pip install .` causes errors if `Cython` is not already installed. This is due to the import/use of `Cython.Build.cythonize` within the `setup.py` file. By adding a `pyproject.toml` file, this can be fixed by causing a temporary `Cython` installation to be used for the setup of `setools`