### PR TITLE
Override copy() and cut() functions for custom tree/table widgets

### DIFF
--- a/setoolsgui/tableview.py
+++ b/setoolsgui/tableview.py
@@ -28,34 +28,32 @@ class SEToolsTableView(QTableView):
     def contextMenuEvent(self, event):
         self.menu.popup(QCursor.pos())
 
-    def event(self, e):
-        if e == QKeySequence.Copy or e == QKeySequence.Cut:
-            datamodel = self.model()
+    def copy(self):
+        datamodel = self.model()
 
-            selected_text = []
-            current_row = None
-            current_col = None
-            prev_row = None
-            prev_col = None
-            for index in sorted(self.selectionModel().selectedIndexes()):
-                current_row = index.row()
-                current_col = index.column()
+        selected_text = []
+        current_row = None
+        current_col = None
+        prev_row = None
+        prev_col = None
+        for index in sorted(self.selectionModel().selectedIndexes()):
+            current_row = index.row()
+            current_col = index.column()
 
-                if prev_row is not None and current_row != prev_row:
-                    selected_text.append('\n')
-                elif prev_col is not None and current_col != prev_col:
-                    selected_text.append('\t')
+            if prev_row is not None and current_row != prev_row:
+                selected_text.append('\n')
+            elif prev_col is not None and current_col != prev_col:
+                selected_text.append('\t')
 
-                selected_text.append(datamodel.data(index, Qt.DisplayRole))
+            selected_text.append(datamodel.data(index, Qt.DisplayRole))
 
-                prev_row = current_row
-                prev_col = current_col
+            prev_row = current_row
+            prev_col = current_col
 
-            QApplication.clipboard().setText("".join(selected_text))
-            return True
+        QApplication.clipboard().setText("".join(selected_text))
 
-        else:
-            return super(SEToolsTableView, self).event(e)
+    def cut(self):
+        self.copy()
 
     def choose_csv_save_location(self):
         filename = QFileDialog.getSaveFileName(self, "Save to CSV", "table.csv",

--- a/setoolsgui/treeview.py
+++ b/setoolsgui/treeview.py
@@ -22,12 +22,12 @@ class SEToolsTreeWidget(QTreeWidget):
         self.menu.addAction(self.copy_tree_action)
 
         # connect signals
-        self.copy_tree_action.triggered.connect(self.copy_tree)
+        self.copy_tree_action.triggered.connect(self.copy)
 
     def contextMenuEvent(self, event):
         self.menu.popup(QCursor.pos())
 
-    def copy_tree(self):
+    def copy(self):
         """Copy the tree to the clipboard."""
 
         items = []
@@ -55,9 +55,5 @@ class SEToolsTreeWidget(QTreeWidget):
 
         QApplication.clipboard().setText("".join(items))
 
-    def event(self, e):
-        if e == QKeySequence.Copy or e == QKeySequence.Cut:
-            self.copy_tree()
-            return True
-        else:
-            return super(SEToolsTreeWidget, self).event(e)
+    def cut(self):
+        self.copy()


### PR DESCRIPTION
The Ctrl-C and Ctrl-X shortcuts are handled by the copy() and cut() functions in the ApolMainWindow, which just get the currently focused widget and call its function of the same name.

However, the custom SEToolsTableView and SEToolsTreeView widgets do not use these functions to implement Ctrl-C/X, but instead override the event() function and check if each received event is a copy/cut key sequence. Functionally this is the same as copy() and cut(), but this leads to an abort in newer versions for Fedora and/or PyQT5 (the reason is not obvious).

To avoid the abort, and arguably make things a little more clear, this overrides the copy() and cut() functions in these widgets, moves the specialize copy logic into them, and removes the event() function.

Closes #77