### PR TITLE
Refine descriptors

### DIFF
--- a/setools/checker/descriptors.py
+++ b/setools/checker/descriptors.py
@@ -28,7 +28,7 @@ class ConfigDescriptor(CriteriaDescriptor):
 
     def __set__(self, obj, value):
         if not value:
-            self.instances[obj] = None
+            setattr(obj, self.name, None)
         else:
             try:
                 super().__set__(obj, value.strip())
@@ -69,7 +69,7 @@ class ConfigSetDescriptor(CriteriaDescriptor):
 
     def __set__(self, obj, value):
         if not value:
-            self.instances[obj] = frozenset()
+            setattr(obj, self.name, frozenset())
         else:
             log = obj.log
             if callable(self.lookup_function):
@@ -94,7 +94,7 @@ class ConfigSetDescriptor(CriteriaDescriptor):
                     log.info("{}: Invalid {} item: {}".format(
                         obj.checkname, self.name, e))
 
-            self.instances[obj] = frozenset(ret)
+            setattr(obj, self.name, frozenset(ret))
 
 
 class ConfigPermissionSetDescriptor(CriteriaPermissionSetDescriptor):
@@ -114,7 +114,7 @@ class ConfigPermissionSetDescriptor(CriteriaPermissionSetDescriptor):
 
     def __set__(self, obj, value):
         if not value:
-            self.instances[obj] = frozenset()
+            setattr(obj, self.name, frozenset())
         else:
             try:
                 super().__set__(obj, (v for v in value.split(" ") if v))

--- a/setools/descriptors.py
+++ b/setools/descriptors.py
@@ -278,7 +278,6 @@ class PermissionMapDescriptor:
     Descriptor for Permission Map mappings.
 
     Parameter:
-    name        The map setting name.
     validator   A callable for validating the setting.
 
     Instance class attribute use (obj parameter):
@@ -287,9 +286,11 @@ class PermissionMapDescriptor:
     perm        The mapping's permission
     """
 
-    def __init__(self, propname: str, validator: Callable):
-        self.name: str = propname
+    def __init__(self, validator: Callable):
         self.validator: Callable = validator
+
+    def __set_name__(self, owner, name):
+        self.name = name
 
     def __get__(self, obj, objtype=None):
         if obj is None:

--- a/setools/descriptors.py
+++ b/setools/descriptors.py
@@ -189,8 +189,8 @@ class NetworkXGraphEdgeDescriptor(ABC):
     """
     Descriptor abstract base class for NetworkX graph edge attributes.
 
-    Parameter:
-    name        The edge property name
+    Keyword Parameter:
+    name        Override the graph edge property name.
 
     Instance class attribute use (obj parameter):
     G           The NetworkX graph
@@ -198,8 +198,11 @@ class NetworkXGraphEdgeDescriptor(ABC):
     target      The edge's target node
     """
 
-    def __init__(self, propname: str) -> None:
-        self.name = propname
+    def __init__(self, propname: Optional[str] = None) -> None:
+        self.override_name = propname
+
+    def __set_name__(self, owner, name):
+        self.name = self.override_name if self.override_name else name
 
     def __get__(self, obj, objtype=None):
         if obj is None:

--- a/setools/diff/typing.py
+++ b/setools/diff/typing.py
@@ -2,7 +2,7 @@
 #
 from typing import DefaultDict, Dict, List, Optional, TypeVar
 
-from ..policyrep import PolicyObject, SELinuxPolicy
+from ..policyrep import PolicyEnum, PolicyObject, SELinuxPolicy
 
 from .difference import Wrapper, SymbolWrapper
 
@@ -12,4 +12,5 @@ U = TypeVar("U", bound=Wrapper)
 Cache = DefaultDict[SELinuxPolicy, Dict[T, U]]
 SymbolCache = Cache[T, SymbolWrapper[T]]
 
-RuleList = Optional[DefaultDict[T, List[U]]]
+E = TypeVar("E", bound=PolicyEnum)
+RuleList = Optional[DefaultDict[E, List[T]]]

--- a/setools/dta.py
+++ b/setools/dta.py
@@ -595,13 +595,13 @@ class Edge:
                 The default is False.
     """
 
-    transition = EdgeAttrList('transition')
-    setexec = EdgeAttrList('setexec')
-    dyntransition = EdgeAttrList('dyntransition')
-    setcurrent = EdgeAttrList('setcurrent')
-    entrypoint = EdgeAttrDict('entrypoint')
-    execute = EdgeAttrDict('execute')
-    type_transition = EdgeAttrDict('type_transition')
+    transition = EdgeAttrList()
+    setexec = EdgeAttrList()
+    dyntransition = EdgeAttrList()
+    setcurrent = EdgeAttrList()
+    entrypoint = EdgeAttrDict()
+    execute = EdgeAttrDict()
+    type_transition = EdgeAttrDict()
 
     def __init__(self, graph, source: Type, target: Type, create: bool = False) -> None:
         self.G = graph

--- a/setools/infoflow.py
+++ b/setools/infoflow.py
@@ -405,7 +405,7 @@ class InfoFlowStep:
                 The default is False.
     """
 
-    rules = EdgeAttrList('rules')
+    rules = EdgeAttrList()
 
     # use capacity to store the info flow weight so
     # we can use network flow algorithms naturally.

--- a/setools/permmap.py
+++ b/setools/permmap.py
@@ -52,9 +52,9 @@ class Mapping:
 
     """A mapping for a permission in the permission map."""
 
-    weight = PermissionMapDescriptor("weight", validate_weight)
-    direction = PermissionMapDescriptor("direction", validate_direction)
-    enabled = PermissionMapDescriptor("enabled", bool)
+    weight = PermissionMapDescriptor(validate_weight)
+    direction = PermissionMapDescriptor(validate_direction)
+    enabled = PermissionMapDescriptor(bool)
     class_: str
     perm: str
 


### PR DESCRIPTION
* Store data in the associated object instead of the descriptor itself, making the weak reference use unnecessary.
* Use `__set_name__()`.