### PR TITLE
diff/permmap: Replace named tuples with dataclasses.

### DIFF
--- a/sediff
+++ b/sediff
@@ -131,8 +131,7 @@ try:
         if diff.modified_properties or args.property:
             print("Policy Properties ({0} Modified)".format(len(diff.modified_properties)))
             if not args.stats:
-                for name, added, removed in sorted(diff.modified_properties,
-                                                   key=lambda x: x.property):
+                for name, added, removed in sorted(diff.modified_properties):
                     print("      * {0} +{1} -{2}".format(name, added, removed))
             print()
             del diff.modified_properties
@@ -475,8 +474,7 @@ try:
                     print("      - {0}".format(r))
             if diff.modified_levels and not args.stats:
                 print("   Modified Levels: {0}".format(len(diff.modified_levels)))
-                for level, added_categories, removed_categories, _ in sorted(diff.modified_levels,
-                                                                             key=lambda x: x.level):
+                for level, added_categories, removed_categories, _ in sorted(diff.modified_levels):
                     change = []
                     if added_categories:
                         change.append("{0} Added Categories".format(len(added_categories)))
@@ -511,8 +509,7 @@ try:
             if diff.modified_allows and not args.stats:
                 print("   Modified Allow Rules: {0}".format(len(diff.modified_allows)))
 
-                for rule, added_perms, removed_perms, matched_perms in sorted(diff.modified_allows,
-                                                                              key=lambda x: x.rule):
+                for rule, added_perms, removed_perms, matched_perms in sorted(diff.modified_allows):
                     perm_str = " ".join(chain((p for p in matched_perms),
                                               ("+" + p for p in added_perms),
                                               ("-" + p for p in removed_perms)))
@@ -551,7 +548,7 @@ try:
                 print("   Modified Allowxperm Rules: {0}".format(len(diff.modified_allowxperms)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_allowxperms, key=lambda x: x.rule):
+                        diff.modified_allowxperms):
 
                     # Process the string representation of the sets
                     # so hex representation and ranges are preserved.
@@ -609,7 +606,7 @@ try:
                 print("   Modified Neverallow Rules: {0}".format(len(diff.modified_neverallows)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_neverallows, key=lambda x: x.rule):
+                        diff.modified_neverallows):
                     perm_str = " ".join(chain((p for p in matched_perms),
                                               ("+" + p for p in added_perms),
                                               ("-" + p for p in removed_perms)))
@@ -651,7 +648,7 @@ try:
                       len(diff.modified_neverallowxperms)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_neverallowxperms, key=lambda x: x.rule):
+                        diff.modified_neverallowxperms):
 
                     # Process the string representation of the sets
                     # so hex representation and ranges are preserved.
@@ -709,7 +706,7 @@ try:
                 print("   Modified Auditallow Rules: {0}".format(len(diff.modified_auditallows)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_auditallows, key=lambda x: x.rule):
+                        diff.modified_auditallows):
                     perm_str = " ".join(chain((p for p in matched_perms),
                                               ("+" + p for p in added_perms),
                                               ("-" + p for p in removed_perms)))
@@ -751,7 +748,7 @@ try:
                       len(diff.modified_auditallowxperms)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_auditallowxperms, key=lambda x: x.rule):
+                        diff.modified_auditallowxperms):
 
                     # Process the string representation of the sets
                     # so hex representation and ranges are preserved.
@@ -809,7 +806,7 @@ try:
                 print("   Modified Dontaudit Rules: {0}".format(len(diff.modified_dontaudits)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_dontaudits, key=lambda x: x.rule):
+                        diff.modified_dontaudits):
                     perm_str = " ".join(chain((p for p in matched_perms),
                                               ("+" + p for p in added_perms),
                                               ("-" + p for p in removed_perms)))
@@ -851,7 +848,7 @@ try:
                       len(diff.modified_dontauditxperms)))
 
                 for rule, added_perms, removed_perms, matched_perms in sorted(
-                        diff.modified_dontauditxperms, key=lambda x: x.rule):
+                        diff.modified_dontauditxperms):
 
                     # Process the string representation of the sets
                     # so hex representation and ranges are preserved.
@@ -911,8 +908,7 @@ try:
                 print("   Modified Type_transition Rules: {0}".format(
                     len(diff.modified_type_transitions)))
 
-                for rule, added_default, removed_default in sorted(diff.modified_type_transitions,
-                                                                   key=lambda x: x.rule):
+                for rule, added_default, removed_default in sorted(diff.modified_type_transitions):
                     rule_string = "{0.ruletype} {0.source} {0.target}:{0.tclass} +{1} -{2}".format(
                         rule, added_default, removed_default)
 
@@ -951,8 +947,7 @@ try:
             if diff.modified_type_changes and not args.stats:
                 print("   Modified Type_change Rules: {0}".format(len(diff.modified_type_changes)))
 
-                for rule, added_default, removed_default in sorted(diff.modified_type_changes,
-                                                                   key=lambda x: x.rule):
+                for rule, added_default, removed_default in sorted(diff.modified_type_changes):
                     rule_string = "{0.ruletype} {0.source} {0.target}:{0.tclass} +{1} -{2}".format(
                         rule, added_default, removed_default)
 
@@ -991,8 +986,7 @@ try:
             if diff.modified_type_members and not args.stats:
                 print("   Modified Type_member Rules: {0}".format(len(diff.modified_type_members)))
 
-                for rule, added_default, removed_default in sorted(diff.modified_type_members,
-                                                                   key=lambda x: x.rule):
+                for rule, added_default, removed_default in sorted(diff.modified_type_members):
                     rule_string = "{0.ruletype} {0.source} {0.target}:{0.tclass} +{1} -{2}".format(
                         rule, added_default, removed_default)
 
@@ -1055,8 +1049,7 @@ try:
                 print("   Modified Role_transition Rules: {0}".format(
                     len(diff.modified_role_transitions)))
 
-                for rule, added_default, removed_default in sorted(diff.modified_role_transitions,
-                                                                   key=lambda x: x.rule):
+                for rule, added_default, removed_default in sorted(diff.modified_role_transitions):
                     rule_string = \
                         "{0.ruletype} {0.source} {0.target}:{0.tclass} +{1} -{2}".format(
                             rule, added_default, removed_default)
@@ -1091,8 +1084,7 @@ try:
                 print("   Modified Range_transition Rules: {0}".format(
                     len(diff.modified_range_transitions)))
 
-                for rule, added_default, removed_default in sorted(diff.modified_range_transitions,
-                                                                   key=lambda x: x.rule):
+                for rule, added_default, removed_default in sorted(diff.modified_range_transitions):
                     # added brackets around range change for clarity since ranges
                     # can have '-' and spaces.
                     rule_string = \
@@ -1231,7 +1223,7 @@ try:
                     print("      - {0}".format(s.statement()))
             if diff.modified_ibendportcons and not args.stats:
                 print("   Modified Ibendportcons: {0}".format(len(diff.modified_ibendportcons)))
-                for entry in sorted(diff.modified_ibendportcons, key=lambda x: x.rule):
+                for entry in sorted(diff.modified_ibendportcons):
                     print("      * ibendportcon {0.rule.name} {0.rule.port} "
                           "+[{0.added_context}] -[{0.removed_context}]".format(entry))
 
@@ -1256,7 +1248,7 @@ try:
                     print("      - {0}".format(s.statement()))
             if diff.modified_ibpkeycons and not args.stats:
                 print("   Modified Ibpkeycons: {0}".format(len(diff.modified_ibpkeycons)))
-                for entry in sorted(diff.modified_ibpkeycons, key=lambda x: x.rule):
+                for entry in sorted(diff.modified_ibpkeycons):
                     if entry.rule.pkeys.low == entry.rule.pkeys.high:
                         print("      * ibpkeycon {0.rule.subnet_prefix} {0.rule.pkeys.low:#x} "
                               "+[{0.added_context}] -[{0.removed_context}]".format(entry))
@@ -1286,7 +1278,7 @@ try:
                     print("      - {0}".format(s))
             if diff.modified_fs_uses and not args.stats:
                 print("   Modified Fs_use: {0}".format(len(diff.modified_fs_uses)))
-                for entry in sorted(diff.modified_fs_uses, key=lambda x: x.rule):
+                for entry in sorted(diff.modified_fs_uses):
                     print("      * {0.ruletype} {0.fs} +[{1}] -[{2}];".format(
                           entry.rule, entry.added_context, entry.removed_context))
 
@@ -1311,7 +1303,7 @@ try:
                     print("      - {0}".format(s))
             if diff.modified_genfscons and not args.stats:
                 print("   Modified Genfscons: {0}".format(len(diff.modified_genfscons)))
-                for entry in sorted(diff.modified_genfscons, key=lambda x: x.rule):
+                for entry in sorted(diff.modified_genfscons):
                     print("      * genfscon {0.fs} {0.path} {0.filetype} +[{1}] -[{2}];".format(
                           entry.rule, entry.added_context, entry.removed_context))
 
@@ -1336,7 +1328,7 @@ try:
                     print("      - {0}".format(n))
             if diff.modified_netifcons and not args.stats:
                 print("   Modified Netifcons: {0}".format(len(diff.modified_netifcons)))
-                for entry in sorted(diff.modified_netifcons, key=lambda x: x.rule):
+                for entry in sorted(diff.modified_netifcons):
                     # This output is different than other statements because
                     # it becomes difficult to read if this was condensed
                     # into a single line, especially if both contexts
@@ -1379,7 +1371,7 @@ try:
                     print("      - {0}".format(n))
             if diff.modified_nodecons and not args.stats:
                 print("   Modified Nodecons: {0}".format(len(diff.modified_nodecons)))
-                for entry in sorted(diff.modified_nodecons, key=lambda x: x.rule):
+                for entry in sorted(diff.modified_nodecons):
                     print("      * nodecon {0} +[{1.added_context}] -[{1.removed_context}];".format(
                           entry.rule.network.with_netmask.replace("/", " "), entry))
 
@@ -1404,8 +1396,7 @@ try:
                     print("      - {0}".format(n))
             if diff.modified_portcons and not args.stats:
                 print("   Modified Portcons: {0}".format(len(diff.modified_portcons)))
-                for con, added_context, removed_context in sorted(diff.modified_portcons,
-                                                                  key=lambda x: x.rule):
+                for con, added_context, removed_context in sorted(diff.modified_portcons):
                     low, high = con.ports
                     if low == high:
                         print("      * portcon {0.protocol} {1} +[{2}] -[{3}];".format(
@@ -1451,7 +1442,7 @@ try:
             if diff.modified_defaults and not args.stats:
                 print("   Modified Defaults: {0}".format(len(diff.modified_defaults)))
                 for default, added_default, removed_default, added_range, removed_range in sorted(
-                        diff.modified_defaults, key=lambda x: x.rule):
+                        diff.modified_defaults):
                     line = "      * {0.ruletype} {0.tclass} ".format(default)
                     if removed_default:
                         line += "+{0} -{1}".format(added_default, removed_default)
@@ -1488,7 +1479,7 @@ try:
             if diff.modified_typebounds and not args.stats:
                 print("   Modified Typebounds: {0}".format(len(diff.modified_typebounds)))
                 for bound, added_bound, removed_bound in sorted(
-                        diff.modified_typebounds, key=lambda x: x.rule):
+                        diff.modified_typebounds):
                     print("      * {0.ruletype} +{1} -{2} {0.child};".format(
                           bound, added_bound, removed_bound))
 

--- a/setools/diff/bool.py
+++ b/setools/diff/bool.py
@@ -4,19 +4,20 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import SELinuxPolicy, Boolean
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 from .typing import SymbolCache
 
 
 _bool_cache: SymbolCache[Boolean] = defaultdict(dict)
 
 
-class ModifiedBoolean(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedBoolean(DifferenceResult):
 
     """Difference details for a modified Boolean."""
 

--- a/setools/diff/bounds.py
+++ b/setools/diff/bounds.py
@@ -3,21 +3,27 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import cast, List, NamedTuple, Optional
+from dataclasses import dataclass
+from typing import cast, List, Optional
 
 from ..policyrep import Bounds, BoundsRuletype, Type
+
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 from .types import type_wrapper_factory
 
 
-class ModifiedBounds(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedBounds(DifferenceResult):
 
     """Difference details for a modified bounds rule."""
 
     rule: Bounds
     added_bound: Type
     removed_bound: Type
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class BoundsDifference(Difference):

--- a/setools/diff/commons.py
+++ b/setools/diff/commons.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple, Set
+from dataclasses import dataclass
+from typing import Set
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 
 
-class ModifiedCommon(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedCommon(DifferenceResult):
 
     """Difference details for a modified common permission set."""
 

--- a/setools/diff/default.py
+++ b/setools/diff/default.py
@@ -2,15 +2,17 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
-from ..policyrep import Default, DefaultRuletype, DefaultValue, DefaultRangeValue, ObjClass
+from ..policyrep import Default, DefaultValue, DefaultRangeValue
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper, Wrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper, Wrapper
 
 
-class ModifiedDefault(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedDefault(DifferenceResult):
 
     """Difference details for a modified default_*."""
 
@@ -19,6 +21,9 @@ class ModifiedDefault(NamedTuple):
     removed_default: Optional[DefaultValue]
     added_default_range: Optional[DefaultRangeValue]
     removed_default_range: Optional[DefaultRangeValue]
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class DefaultsDifference(Difference):

--- a/setools/diff/difference.py
+++ b/setools/diff/difference.py
@@ -7,6 +7,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Generic, Iterable, TypeVar
 
+from ..mixins import TupleCompat
 from ..policyrep import PolicyObject, PolicySymbol, SELinuxPolicy
 
 
@@ -115,6 +116,13 @@ class Difference:
                 set((left.origin, right.origin) for (left, right) in matched_items)
         else:
             return added_items, removed_items, matched_items
+
+
+class DifferenceResult(TupleCompat):
+
+    """Base class for difference results"""
+
+    pass
 
 
 T = TypeVar("T", bound=PolicyObject)

--- a/setools/diff/fsuse.py
+++ b/setools/diff/fsuse.py
@@ -2,22 +2,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context, FSUse
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedFSUse(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedFSUse(DifferenceResult):
 
     """Difference details for a modified fs_use_*."""
 
     rule: FSUse
     added_context: Context
     removed_context: Context
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class FSUsesDifference(Difference):

--- a/setools/diff/genfscon.py
+++ b/setools/diff/genfscon.py
@@ -2,22 +2,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context, Genfscon
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedGenfscon(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedGenfscon(DifferenceResult):
 
     """Difference details for a modified genfscons."""
 
     rule: Genfscon
     added_context: Context
     removed_context: Context
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class GenfsconsDifference(Difference):

--- a/setools/diff/ibendportcon.py
+++ b/setools/diff/ibendportcon.py
@@ -2,21 +2,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context, Ibendportcon
+
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedIbendportcon(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedIbendportcon(DifferenceResult):
 
     """Difference details for a modified ibendportcon."""
 
     rule: Ibendportcon
     added_context: Context
     removed_context: Context
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class IbendportconsDifference(Difference):

--- a/setools/diff/ibpkeycon.py
+++ b/setools/diff/ibpkeycon.py
@@ -2,22 +2,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context, Ibpkeycon
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedIbpkeycon(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedIbpkeycon(DifferenceResult):
 
     """Difference details for a modified ibpkeycon."""
 
     rule: Ibpkeycon
     added_context: Context
     removed_context: Context
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class IbpkeyconsDifference(Difference):

--- a/setools/diff/initsid.py
+++ b/setools/diff/initsid.py
@@ -2,16 +2,17 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 
 
-class ModifiedInitialSID(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedInitialSID(DifferenceResult):
 
     """Difference details for a modified initial SID."""
 

--- a/setools/diff/mls.py
+++ b/setools/diff/mls.py
@@ -4,19 +4,21 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple, Set
+from dataclasses import dataclass
+from typing import Set
 
 from ..policyrep import Category, Level, LevelDecl, Range, Sensitivity
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper, Wrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper, Wrapper
 from .typing import SymbolCache
 
 _cats_cache: SymbolCache[Category] = defaultdict(dict)
 _sens_cache: SymbolCache[Sensitivity] = defaultdict(dict)
 
 
-class ModifiedCategory(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedCategory(DifferenceResult):
 
     """Difference details for a modified category."""
 
@@ -25,7 +27,8 @@ class ModifiedCategory(NamedTuple):
     matched_aliases: Set[str]
 
 
-class ModifiedSensitivity(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedSensitivity(DifferenceResult):
 
     """Difference details for a modified sensitivity."""
 
@@ -34,7 +37,8 @@ class ModifiedSensitivity(NamedTuple):
     matched_aliases: Set[str]
 
 
-class ModifiedLevelDecl(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedLevelDecl(DifferenceResult):
 
     """Difference details for a modified level declaration."""
 
@@ -42,6 +46,9 @@ class ModifiedLevelDecl(NamedTuple):
     added_categories: Set[Category]
     removed_categories: Set[Category]
     matched_categories: Set[Category]
+
+    def __lt__(self, other) -> bool:
+        return self.level < other.level
 
 
 def category_wrapper_factory(category: Category) -> SymbolWrapper[Category]:

--- a/setools/diff/mlsrules.py
+++ b/setools/diff/mlsrules.py
@@ -4,25 +4,29 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import MLSRule, MLSRuletype, Range
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 from .mls import RangeWrapper
 from .objclass import class_wrapper_factory
 from .types import type_or_attr_wrapper_factory
 from .typing import RuleList
 
 
-class ModifiedMLSRule(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedMLSRule(DifferenceResult):
 
     """Difference details for a modified MLS rule."""
 
     rule: MLSRule
     added_default: Range
     removed_default: Range
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class MLSRulesDifference(Difference):

--- a/setools/diff/netifcon.py
+++ b/setools/diff/netifcon.py
@@ -2,16 +2,18 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from ..policyrep import Context, Netifcon
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedNetifcon(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedNetifcon(DifferenceResult):
 
     """Difference details for a modified netifcon."""
 
@@ -20,6 +22,9 @@ class ModifiedNetifcon(NamedTuple):
     removed_context: Optional[Context]
     added_packet: Optional[Context]
     removed_packet: Optional[Context]
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class NetifconsDifference(Difference):

--- a/setools/diff/nodecon.py
+++ b/setools/diff/nodecon.py
@@ -3,22 +3,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context, Nodecon
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedNodecon(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedNodecon(DifferenceResult):
 
     """Difference details for a modified netifcon."""
 
     rule: Nodecon
     added_context: Context
     removed_context: Context
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class NodeconsDifference(Difference):

--- a/setools/diff/objclass.py
+++ b/setools/diff/objclass.py
@@ -5,19 +5,21 @@
 #
 from collections import defaultdict
 from contextlib import suppress
-from typing import NamedTuple, Set
+from dataclasses import dataclass
+from typing import Set
 
 from ..exception import NoCommon
 from ..policyrep import ObjClass
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 from .typing import SymbolCache
 
 _class_cache: SymbolCache[ObjClass] = defaultdict(dict)
 
 
-class ModifiedObjClass(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedObjClass(DifferenceResult):
 
     """Difference details for a modified object class."""
 

--- a/setools/diff/portcon.py
+++ b/setools/diff/portcon.py
@@ -2,22 +2,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import Context, Portcon
 
 from .context import ContextWrapper
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 
 
-class ModifiedPortcon(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedPortcon(DifferenceResult):
 
     """Difference details for a modified portcon."""
 
     rule: Portcon
     added_context: Context
     removed_context: Context
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class PortconsDifference(Difference):

--- a/setools/diff/properties.py
+++ b/setools/diff/properties.py
@@ -2,21 +2,26 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import NamedTuple, Union
+from dataclasses import dataclass
+from typing import Union
 
 from ..policyrep import PolicyEnum
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference
+from .difference import Difference, DifferenceResult
 
 
-class ModifiedProperty(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedProperty(DifferenceResult):
 
     """Difference details for a modified policy property."""
 
     property: str
     added: Union[PolicyEnum, bool, int]
     removed: Union[PolicyEnum, bool, int]
+
+    def __lt__(self, other) -> bool:
+        return self.property < other.property
 
 
 class PropertiesDifference(Difference):

--- a/setools/diff/rbacrules.py
+++ b/setools/diff/rbacrules.py
@@ -4,25 +4,29 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from ..policyrep import AnyRBACRule, RBACRuletype, Role, RoleAllow, RoleTransition
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 from .objclass import class_wrapper_factory
 from .roles import role_wrapper_factory
 from .types import type_or_attr_wrapper_factory
 from .typing import RuleList
 
 
-class ModifiedRBACRule(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedRBACRule(DifferenceResult):
 
     """Difference details for a modified RBAC rule."""
 
     rule: AnyRBACRule
     added_default: Role
     removed_default: Role
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 class RBACRulesDifference(Difference):

--- a/setools/diff/roles.py
+++ b/setools/diff/roles.py
@@ -4,19 +4,21 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple, Set
+from dataclasses import dataclass
+from typing import Set
 
 from ..policyrep import Role, Type
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 from .typing import SymbolCache
 from .types import type_wrapper_factory
 
 _roles_cache: SymbolCache[Role] = defaultdict(dict)
 
 
-class ModifiedRole(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedRole(DifferenceResult):
 
     """Difference details for a modified role."""
 

--- a/setools/diff/terules.py
+++ b/setools/diff/terules.py
@@ -5,16 +5,17 @@
 #
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from sys import intern
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from ..exception import RuleNotConditional, RuleUseError, TERuleNoFilename
 from ..policyrep import AnyTERule, AVRule, AVRuleXperm, Conditional, IoctlSet, TERuletype, Type
 
 from .conditional import conditional_wrapper_factory
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, Wrapper
+from .difference import Difference, DifferenceResult, Wrapper
 from .types import type_wrapper_factory, type_or_attr_wrapper_factory
 from .typing import RuleList
 from .objclass import class_wrapper_factory
@@ -23,7 +24,8 @@ TERULES_UNCONDITIONAL = intern("<<unconditional>>")
 TERULES_UNCONDITIONAL_BLOCK = intern("True")
 
 
-class ModifiedAVRule(NamedTuple):
+@dataclass(frozen=True)
+class ModifiedAVRule(DifferenceResult):
 
     """Difference details for a modified access vector rule."""
 
@@ -32,14 +34,21 @@ class ModifiedAVRule(NamedTuple):
     removed_perms: Union[Set[str], IoctlSet]
     matched_perms: Union[Set[str], IoctlSet]
 
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
-class ModifiedTERule(NamedTuple):
+
+@dataclass(frozen=True)
+class ModifiedTERule(DifferenceResult):
 
     """Difference details for a modified type_* rule."""
 
     rule: AVRule
     added_default: Type
     removed_default: Type
+
+    def __lt__(self, other) -> bool:
+        return self.rule < other.rule
 
 
 #
@@ -50,17 +59,20 @@ class Side(Enum):
     right = 1
 
 
-class RuleDBSideDataRecord(NamedTuple):
+@dataclass
+class RuleDBSideDataRecord:
     perms: Set[str]
     orig_rule: AVRule
 
 
-class RuleDBSidesRecord(NamedTuple):
+@dataclass
+class RuleDBSidesRecord:
     left: Optional[RuleDBSideDataRecord]
     right: Optional[RuleDBSideDataRecord]
 
 
-class TypeDBRecord(NamedTuple):
+@dataclass
+class TypeDBRecord:
     left: Dict[str, Type]
     right: Dict[str, Type]
 

--- a/setools/diff/typeattr.py
+++ b/setools/diff/typeattr.py
@@ -4,18 +4,20 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple, Set
+from dataclasses import dataclass
+from typing import Set
 
 from ..policyrep import Type, TypeAttribute
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 from .typing import SymbolCache
 
 _typeattr_cache: SymbolCache[TypeAttribute] = defaultdict(dict)
 
 
-class ModifiedTypeAttribute(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedTypeAttribute(DifferenceResult):
 
     """Difference details for a modified type attribute."""
 

--- a/setools/diff/types.py
+++ b/setools/diff/types.py
@@ -4,19 +4,21 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple, Set, Union
+from dataclasses import dataclass
+from typing import Set, Union
 
 from ..policyrep import Type, TypeAttribute, TypeOrAttr
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 from .typeattr import typeattr_wrapper_factory
 from .typing import SymbolCache
 
 _types_cache: SymbolCache[Type] = defaultdict(dict)
 
 
-class ModifiedType(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedType(DifferenceResult):
 
     """Difference details for a modified type."""
 

--- a/setools/diff/typing.py
+++ b/setools/diff/typing.py
@@ -1,16 +1,20 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-from typing import DefaultDict, Dict, List, Optional, TypeVar
+from typing import DefaultDict, Dict, List, Optional, TypeVar, Union
 
-from ..policyrep import PolicyEnum, PolicyObject, SELinuxPolicy
+from ..policyrep import AnyConstraint, PolicyEnum, PolicyObject, PolicyRule, PolicySymbol, \
+                        SELinuxPolicy
 
 from .difference import Wrapper, SymbolWrapper
 
 
-T = TypeVar("T", bound=PolicyObject)
-U = TypeVar("U", bound=Wrapper)
-Cache = DefaultDict[SELinuxPolicy, Dict[T, U]]
-SymbolCache = Cache[T, SymbolWrapper[T]]
+PE = TypeVar("PE", bound=PolicyEnum)
+PO = TypeVar("PO", bound=PolicyObject)
+PS = TypeVar("PS", bound=PolicySymbol)
+PR = TypeVar("PR", bound=Union[AnyConstraint, PolicyRule])
+WR = TypeVar("WR", bound=Wrapper)
 
-E = TypeVar("E", bound=PolicyEnum)
-RuleList = Optional[DefaultDict[E, List[T]]]
+Cache = DefaultDict[SELinuxPolicy, Dict[PO, WR]]
+SymbolCache = Cache[PS, SymbolWrapper[PS]]
+
+RuleList = Optional[DefaultDict[PE, List[PR]]]

--- a/setools/diff/users.py
+++ b/setools/diff/users.py
@@ -4,13 +4,14 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 from collections import defaultdict
-from typing import NamedTuple, Set, Optional, Union
+from dataclasses import dataclass
+from typing import Set, Optional, Union
 
 from ..exception import MLSDisabled
 from ..policyrep import Level, Range, Role, User
 
 from .descriptors import DiffResultDescriptor
-from .difference import Difference, SymbolWrapper
+from .difference import Difference, DifferenceResult, SymbolWrapper
 from .mls import LevelWrapper, RangeWrapper
 from .roles import role_wrapper_factory
 from .typing import SymbolCache
@@ -18,7 +19,8 @@ from .typing import SymbolCache
 _users_cache: SymbolCache[User] = defaultdict(dict)
 
 
-class ModifiedUser(NamedTuple):
+@dataclass(frozen=True, order=True)
+class ModifiedUser(DifferenceResult):
 
     """Difference details for a modified user."""
 

--- a/setools/infoflow.py
+++ b/setools/infoflow.py
@@ -313,21 +313,21 @@ class InfoFlowAnalysis:
             if rule.ruletype != TERuletype.allow:
                 continue
 
-            (rweight, wweight) = self.perm_map.rule_weight(cast(AVRule, rule))
+            weight = self.perm_map.rule_weight(cast(AVRule, rule))
 
             for s, t in itertools.product(rule.source.expand(), rule.target.expand()):
                 # only add flows if they actually flow
                 # in or out of the source type type
                 if s != t:
-                    if wweight:
+                    if weight.write:
                         edge = InfoFlowStep(self.G, s, t, create=True)
                         edge.rules.append(rule)
-                        edge.weight = wweight
+                        edge.weight = weight.write
 
-                    if rweight:
+                    if weight.read:
                         edge = InfoFlowStep(self.G, t, s, create=True)
                         edge.rules.append(rule)
-                        edge.weight = rweight
+                        edge.weight = weight.read
 
         self.rebuildgraph = False
         self.rebuildsubgraph = True

--- a/setools/mixins.py
+++ b/setools/mixins.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 # pylint: disable=attribute-defined-outside-init,no-member
-import re
+from dataclasses import astuple
 from logging import Logger
 from typing import Any
+import warnings
 
 from .descriptors import CriteriaDescriptor, CriteriaSetDescriptor, CriteriaPermissionSetDescriptor
 from .policyrep import Context
@@ -233,3 +234,23 @@ class NetworkXGraphEdge:
             return self.target
         else:
             raise IndexError(f"Invalid index (NetworkXGraphEdge only has 2 items): {index}")
+
+
+class TupleCompat:
+
+    """Mixin for named tuple backwards compatibility for dataclasses."""
+
+    def __getitem__(self, key):
+        warnings.warn("Named tuple returns are deprecated, replaced with dataclasses.",
+                      DeprecationWarning)
+        return astuple(self)[key]
+
+    def __iter__(self):
+        warnings.warn("Named tuple returns are deprecated, replaced with dataclasses.",
+                      DeprecationWarning)
+        return iter(astuple(self))
+
+    def __len__(self):
+        warnings.warn("Named tuple returns are deprecated, replaced with dataclasses.",
+                      DeprecationWarning)
+        return len(astuple(self))

--- a/setools/permmap.py
+++ b/setools/permmap.py
@@ -6,12 +6,14 @@ import logging
 import copy
 from collections import OrderedDict
 from contextlib import suppress
-from typing import cast, Dict, Iterable, NamedTuple, Optional, Union
+from dataclasses import dataclass
+from typing import cast, Dict, Iterable, Optional, Union
 
 import pkg_resources
 
 from . import exception
 from .descriptors import PermissionMapDescriptor
+from .mixins import TupleCompat
 from .policyrep import AVRule, SELinuxPolicy, TERuletype
 
 INFOFLOW_DIRECTIONS = ("r", "w", "b", "n", "u")
@@ -19,7 +21,8 @@ MIN_WEIGHT = 1
 MAX_WEIGHT = 10
 
 
-class RuleWeight(NamedTuple):
+@dataclass
+class RuleWeight(TupleCompat):
 
     """The read and write weights for a rule, given all of its permissions."""
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -5,9 +5,10 @@
 #
 import os
 import unittest
+from dataclasses import astuple
 from ipaddress import IPv6Address, IPv4Network, IPv6Network
 
-from setools import SELinuxPolicy, PolicyDifference, PortconProtocol
+from setools import PolicyDifference, PortconProtocol
 from setools import BoundsRuletype as BRT
 from setools import ConstraintRuletype as CRT
 from setools import DefaultRuletype as DRT
@@ -275,7 +276,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # add permissions
-        rule, added_perms, removed_perms, matched_perms = lst[0]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[0])
         self.assertEqual(TRT.allow, rule.ruletype)
         self.assertEqual("modified_rule_add_perms", rule.source)
         self.assertEqual("modified_rule_add_perms", rule.target)
@@ -285,7 +286,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set(["hi_r"]), matched_perms)
 
         # add and remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[1]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[1])
         self.assertEqual(TRT.allow, rule.ruletype)
         self.assertEqual("modified_rule_add_remove_perms", rule.source)
         self.assertEqual("modified_rule_add_remove_perms", rule.target)
@@ -295,7 +296,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set(["low_w"]), matched_perms)
 
         # remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[2]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[2])
         self.assertEqual(TRT.allow, rule.ruletype)
         self.assertEqual("modified_rule_remove_perms", rule.source)
         self.assertEqual("modified_rule_remove_perms", rule.target)
@@ -363,7 +364,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # add permissions
-        rule, added_perms, removed_perms, matched_perms = lst[0]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[0])
         self.assertEqual(TRT.auditallow, rule.ruletype)
         self.assertEqual("aa_modified_rule_add_perms", rule.source)
         self.assertEqual("aa_modified_rule_add_perms", rule.target)
@@ -373,7 +374,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set(["hi_r"]), matched_perms)
 
         # add and remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[1]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[1])
         self.assertEqual(TRT.auditallow, rule.ruletype)
         self.assertEqual("aa_modified_rule_add_remove_perms", rule.source)
         self.assertEqual("aa_modified_rule_add_remove_perms", rule.target)
@@ -383,7 +384,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set(["low_w"]), matched_perms)
 
         # remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[2]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[2])
         self.assertEqual(TRT.auditallow, rule.ruletype)
         self.assertEqual("aa_modified_rule_remove_perms", rule.source)
         self.assertEqual("aa_modified_rule_remove_perms", rule.target)
@@ -451,7 +452,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # add permissions
-        rule, added_perms, removed_perms, matched_perms = lst[0]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[0])
         self.assertEqual(TRT.dontaudit, rule.ruletype)
         self.assertEqual("da_modified_rule_add_perms", rule.source)
         self.assertEqual("da_modified_rule_add_perms", rule.target)
@@ -461,7 +462,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set(["hi_r"]), matched_perms)
 
         # add and remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[1]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[1])
         self.assertEqual(TRT.dontaudit, rule.ruletype)
         self.assertEqual("da_modified_rule_add_remove_perms", rule.source)
         self.assertEqual("da_modified_rule_add_remove_perms", rule.target)
@@ -471,7 +472,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set(["low_w"]), matched_perms)
 
         # remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[2]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[2])
         self.assertEqual(TRT.dontaudit, rule.ruletype)
         self.assertEqual("da_modified_rule_remove_perms", rule.source)
         self.assertEqual("da_modified_rule_remove_perms", rule.target)
@@ -609,7 +610,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_type_transitions, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_default, removed_default = lst[0]
+        rule, added_default, removed_default = astuple(lst[0])
         self.assertEqual(TRT.type_transition, rule.ruletype)
         self.assertEqual("tt_matched_source", rule.source)
         self.assertEqual("system", rule.target)
@@ -675,7 +676,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_type_changes, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_default, removed_default = lst[0]
+        rule, added_default, removed_default = astuple(lst[0])
         self.assertEqual(TRT.type_change, rule.ruletype)
         self.assertEqual("tc_matched_source", rule.source)
         self.assertEqual("system", rule.target)
@@ -741,7 +742,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_type_members, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_default, removed_default = lst[0]
+        rule, added_default, removed_default = astuple(lst[0])
         self.assertEqual(TRT.type_member, rule.ruletype)
         self.assertEqual("tm_matched_source", rule.source)
         self.assertEqual("system", rule.target)
@@ -783,7 +784,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_range_transitions, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_default, removed_default = lst[0]
+        rule, added_default, removed_default = astuple(lst[0])
         self.assertEqual(MRT.range_transition, rule.ruletype)
         self.assertEqual("rt_matched_source", rule.source)
         self.assertEqual("system", rule.target)
@@ -858,7 +859,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_role_transitions, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_default, removed_default = lst[0]
+        rule, added_default, removed_default = astuple(lst[0])
         self.assertEqual(RRT.role_transition, rule.ruletype)
         self.assertEqual("role_tr_matched_source", rule.source)
         self.assertEqual("role_tr_matched_target", rule.target)
@@ -1035,7 +1036,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_fs_uses, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_context, removed_context = lst[0]
+        rule, added_context, removed_context = astuple(lst[0])
         self.assertEqual(FSURT.fs_use_trans, rule.ruletype)
         self.assertEqual("modified_fsuse", rule.fs)
         self.assertEqual("added_user:object_r:system:s1", added_context)
@@ -1079,7 +1080,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_genfscons, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        rule, added_context, removed_context = lst[0]
+        rule, added_context, removed_context = astuple(lst[0])
         self.assertEqual("modified_genfs", rule.fs)
         self.assertEqual("/", rule.path)
         self.assertEqual("added_user:object_r:system:s0", added_context)
@@ -1144,7 +1145,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # modified both contexts
-        rule, added_context, removed_context, added_packet, removed_packet = lst[0]
+        rule, added_context, removed_context, added_packet, removed_packet = astuple(lst[0])
         self.assertEqual("mod_both_netif", rule.netif)
         self.assertEqual("added_user:object_r:system:s0", added_context)
         self.assertEqual("removed_user:object_r:system:s0", removed_context)
@@ -1152,7 +1153,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual("removed_user:object_r:system:s0", removed_packet)
 
         # modified context
-        rule, added_context, removed_context, added_packet, removed_packet = lst[1]
+        rule, added_context, removed_context, added_packet, removed_packet = astuple(lst[1])
         self.assertEqual("mod_ctx_netif", rule.netif)
         self.assertEqual("added_user:object_r:system:s0", added_context)
         self.assertEqual("removed_user:object_r:system:s0", removed_context)
@@ -1160,7 +1161,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertIsNone(removed_packet)
 
         # modified packet context
-        rule, added_context, removed_context, added_packet, removed_packet = lst[2]
+        rule, added_context, removed_context, added_packet, removed_packet = astuple(lst[2])
         self.assertEqual("mod_pkt_netif", rule.netif)
         self.assertIsNone(added_context)
         self.assertIsNone(removed_context)
@@ -1218,13 +1219,13 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(2, len(lst))
 
         # changed IPv4
-        nodecon, added_context, removed_context = lst[0]
+        nodecon, added_context, removed_context = astuple(lst[0])
         self.assertEqual(IPv4Network("123.0.0.0/8"), nodecon.network)
         self.assertEqual("modified_change_level:object_r:system:s2:c0", added_context)
         self.assertEqual("modified_change_level:object_r:system:s2:c1", removed_context)
 
         # changed IPv6
-        nodecon, added_context, removed_context = lst[1]
+        nodecon, added_context, removed_context = astuple(lst[1])
         self.assertEqual(IPv6Network("ff03::/62"), nodecon.network)
         self.assertEqual("modified_change_level:object_r:system:s2:c1", added_context)
         self.assertEqual("modified_change_level:object_r:system:s2:c0.c1", removed_context)
@@ -1274,13 +1275,13 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_portcons, key=lambda x: x.rule)
         self.assertEqual(2, len(lst))
 
-        portcon, added_context, removed_context = lst[0]
+        portcon, added_context, removed_context = astuple(lst[0])
         self.assertEqual(PortconProtocol.tcp, portcon.protocol)
         self.assertTupleEqual((3024, 3026), portcon.ports)
         self.assertEqual("added_user:object_r:system:s1", added_context)
         self.assertEqual("removed_user:object_r:system:s0", removed_context)
 
-        portcon, added_context, removed_context = lst[1]
+        portcon, added_context, removed_context = astuple(lst[1])
         self.assertEqual(PortconProtocol.udp, portcon.protocol)
         self.assertTupleEqual((3024, 3024), portcon.ports)
         self.assertEqual("added_user:object_r:system:s1", added_context)
@@ -1320,7 +1321,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_defaults, key=lambda x: x.rule)
         self.assertEqual(4, len(lst))
 
-        default, added_default, removed_default, added_range, removed_range = lst[0]
+        default, added_default, removed_default, added_range, removed_range = astuple(lst[0])
         self.assertEqual(DRT.default_range, default.ruletype)
         self.assertEqual("infoflow4", default.tclass)
         self.assertEqual(DV.target, added_default)
@@ -1328,7 +1329,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertIsNone(added_range)
         self.assertIsNone(removed_range)
 
-        default, added_default, removed_default, added_range, removed_range = lst[1]
+        default, added_default, removed_default, added_range, removed_range = astuple(lst[1])
         self.assertEqual(DRT.default_range, default.ruletype)
         self.assertEqual("infoflow5", default.tclass)
         self.assertIsNone(added_default)
@@ -1336,7 +1337,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(DRV.high, added_range)
         self.assertEqual(DRV.low, removed_range)
 
-        default, added_default, removed_default, added_range, removed_range = lst[2]
+        default, added_default, removed_default, added_range, removed_range = astuple(lst[2])
         self.assertEqual(DRT.default_range, default.ruletype)
         self.assertEqual("infoflow6", default.tclass)
         self.assertEqual(DV.target, added_default)
@@ -1344,7 +1345,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(DRV.low, added_range)
         self.assertEqual(DRV.high, removed_range)
 
-        default, added_default, removed_default, added_range, removed_range = lst[3]
+        default, added_default, removed_default, added_range, removed_range = astuple(lst[3])
         self.assertEqual(DRT.default_type, default.ruletype)
         self.assertEqual("infoflow4", default.tclass)
         self.assertEqual(DV.target, added_default)
@@ -1552,7 +1553,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         lst = sorted(self.diff.modified_typebounds, key=lambda x: x.rule)
         self.assertEqual(1, len(lst))
 
-        bounds, added_bound, removed_bound = lst[0]
+        bounds, added_bound, removed_bound = astuple(lst[0])
         self.assertEqual(BRT.typebounds, bounds.ruletype)
         self.assertEqual("mod_child", bounds.child)
         self.assertEqual("mod_parent_added", added_bound)
@@ -1593,7 +1594,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # add permissions
-        rule, added_perms, removed_perms, matched_perms = lst[0]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[0])
         self.assertEqual(TRT.allowxperm, rule.ruletype)
         self.assertEqual("ax_modified_rule_add_perms", rule.source)
         self.assertEqual("ax_modified_rule_add_perms", rule.target)
@@ -1603,7 +1604,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set([0x0004]), matched_perms)
 
         # add and remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[1]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[1])
         self.assertEqual(TRT.allowxperm, rule.ruletype)
         self.assertEqual("ax_modified_rule_add_remove_perms", rule.source)
         self.assertEqual("ax_modified_rule_add_remove_perms", rule.target)
@@ -1613,7 +1614,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set([0x0008]), matched_perms)
 
         # remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[2]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[2])
         self.assertEqual(TRT.allowxperm, rule.ruletype)
         self.assertEqual("ax_modified_rule_remove_perms", rule.source)
         self.assertEqual("ax_modified_rule_remove_perms", rule.target)
@@ -1657,7 +1658,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # add permissions
-        rule, added_perms, removed_perms, matched_perms = lst[0]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[0])
         self.assertEqual(TRT.auditallowxperm, rule.ruletype)
         self.assertEqual("aax_modified_rule_add_perms", rule.source)
         self.assertEqual("aax_modified_rule_add_perms", rule.target)
@@ -1667,7 +1668,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set([0x0004]), matched_perms)
 
         # add and remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[1]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[1])
         self.assertEqual(TRT.auditallowxperm, rule.ruletype)
         self.assertEqual("aax_modified_rule_add_remove_perms", rule.source)
         self.assertEqual("aax_modified_rule_add_remove_perms", rule.target)
@@ -1677,7 +1678,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set([0x0008]), matched_perms)
 
         # remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[2]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[2])
         self.assertEqual(TRT.auditallowxperm, rule.ruletype)
         self.assertEqual("aax_modified_rule_remove_perms", rule.source)
         self.assertEqual("aax_modified_rule_remove_perms", rule.target)
@@ -1791,7 +1792,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertEqual(3, len(lst))
 
         # add permissions
-        rule, added_perms, removed_perms, matched_perms = lst[0]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[0])
         self.assertEqual(TRT.dontauditxperm, rule.ruletype)
         self.assertEqual("dax_modified_rule_add_perms", rule.source)
         self.assertEqual("dax_modified_rule_add_perms", rule.target)
@@ -1801,7 +1802,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set([0x0004]), matched_perms)
 
         # add and remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[1]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[1])
         self.assertEqual(TRT.dontauditxperm, rule.ruletype)
         self.assertEqual("dax_modified_rule_add_remove_perms", rule.source)
         self.assertEqual("dax_modified_rule_add_remove_perms", rule.target)
@@ -1811,7 +1812,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         self.assertSetEqual(set([0x0008]), matched_perms)
 
         # remove permissions
-        rule, added_perms, removed_perms, matched_perms = lst[2]
+        rule, added_perms, removed_perms, matched_perms = astuple(lst[2])
         self.assertEqual(TRT.dontauditxperm, rule.ruletype)
         self.assertEqual("dax_modified_rule_remove_perms", rule.source)
         self.assertEqual("dax_modified_rule_remove_perms", rule.target)
@@ -1844,7 +1845,7 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         rules = sorted(self.diff.modified_ibendportcons)
         self.assertEqual(1, len(rules))
 
-        rule, added, removed = rules[0]
+        rule, added, removed = astuple(rules[0])
         self.assertEqual("modified", rule.name)
         self.assertEqual(13, rule.port)
         self.assertEqual("modified_change_level:object_r:system:s2", added)
@@ -1892,14 +1893,14 @@ class PolicyDifferenceTest(ValidateRule, unittest.TestCase):
         rules = sorted(self.diff.modified_ibpkeycons)
         self.assertEqual(2, len(rules))
 
-        rule, added, removed = rules[0]
+        rule, added, removed = astuple(rules[0])
         self.assertEqual(IPv6Address("aaaa::"), rule.subnet_prefix)
         self.assertEqual(0xcccc, rule.pkeys.low)
         self.assertEqual(0xdddd, rule.pkeys.high)
         self.assertEqual("modified_change_level:object_r:system:s2:c0", added)
         self.assertEqual("modified_change_level:object_r:system:s2:c1", removed)
 
-        rule, added, removed = rules[1]
+        rule, added, removed = astuple(rules[1])
         self.assertEqual(IPv6Address("bbbb::"), rule.subnet_prefix)
         self.assertEqual(0xf, rule.pkeys.low)
         self.assertEqual(0xf, rule.pkeys.high)
@@ -2738,7 +2739,7 @@ class PolicyDifferenceTestMLStoStandard(unittest.TestCase):
         """MLSvsStandardDiff: MLS property modified only."""
         self.assertEqual(1, len(self.diff.modified_properties))
 
-        name, added, removed = self.diff.modified_properties[0]
+        name, added, removed = astuple(self.diff.modified_properties[0])
         self.assertEqual("MLS", name)
         self.assertIs(False, added)
         self.assertIs(True, removed)

--- a/tests/test_permmap.py
+++ b/tests/test_permmap.py
@@ -285,9 +285,9 @@ class PermissionMapTest(unittest.TestCase):
         rule.perms = set(["med_r", "hi_r"])
 
         permmap = PermissionMap("tests/perm_map")
-        r, w = permmap.rule_weight(rule)
-        self.assertEqual(r, 10)
-        self.assertEqual(w, 0)
+        weight = permmap.rule_weight(rule)
+        self.assertEqual(weight.read, 10)
+        self.assertEqual(weight.write, 0)
 
     def test_141_weight_write_only(self):
         """PermMap get weight of write-only rule."""
@@ -297,9 +297,9 @@ class PermissionMapTest(unittest.TestCase):
         rule.perms = set(["low_w", "med_w"])
 
         permmap = PermissionMap("tests/perm_map")
-        r, w = permmap.rule_weight(rule)
-        self.assertEqual(r, 0)
-        self.assertEqual(w, 5)
+        weight = permmap.rule_weight(rule)
+        self.assertEqual(weight.read, 0)
+        self.assertEqual(weight.write, 5)
 
     def test_142_weight_both(self):
         """PermMap get weight of both rule."""
@@ -309,9 +309,9 @@ class PermissionMapTest(unittest.TestCase):
         rule.perms = set(["low_r", "hi_w"])
 
         permmap = PermissionMap("tests/perm_map")
-        r, w = permmap.rule_weight(rule)
-        self.assertEqual(r, 1)
-        self.assertEqual(w, 10)
+        weight = permmap.rule_weight(rule)
+        self.assertEqual(weight.read, 1)
+        self.assertEqual(weight.write, 10)
 
     def test_143_weight_none(self):
         """PermMap get weight of none rule."""
@@ -321,9 +321,9 @@ class PermissionMapTest(unittest.TestCase):
         rule.perms = set(["null"])
 
         permmap = PermissionMap("tests/perm_map")
-        r, w = permmap.rule_weight(rule)
-        self.assertEqual(r, 0)
-        self.assertEqual(w, 0)
+        weight = permmap.rule_weight(rule)
+        self.assertEqual(weight.read, 0)
+        self.assertEqual(weight.write, 0)
 
     def test_144_weight_unmapped_class(self):
         """PermMap get weight of rule with unmapped class."""
@@ -363,9 +363,9 @@ class PermissionMapTest(unittest.TestCase):
 
         permmap = PermissionMap("tests/perm_map")
         permmap.exclude_permission("infoflow", "hi_r")
-        r, w = permmap.rule_weight(rule)
-        self.assertEqual(r, 5)
-        self.assertEqual(w, 0)
+        weight = permmap.rule_weight(rule)
+        self.assertEqual(weight.read, 5)
+        self.assertEqual(weight.write, 0)
 
     def test_148_weight_excluded_class(self):
         """PermMap get weight of a rule with excluded class."""
@@ -376,9 +376,9 @@ class PermissionMapTest(unittest.TestCase):
 
         permmap = PermissionMap("tests/perm_map")
         permmap.exclude_class("infoflow")
-        r, w = permmap.rule_weight(rule)
-        self.assertEqual(r, 0)
-        self.assertEqual(w, 0)
+        weight = permmap.rule_weight(rule)
+        self.assertEqual(weight.read, 0)
+        self.assertEqual(weight.write, 0)
 
     def test_150_map_policy(self):
         """PermMap create mappings for classes/perms in a policy."""


### PR DESCRIPTION
Add backwards compatibility for tuple usage.