### PR TITLE
seinfoflow: Add -r option to get flows into the source type.

### DIFF
--- a/man/seinfoflow.1
+++ b/man/seinfoflow.1
@@ -50,6 +50,8 @@ Specify the maximum number of information flows to output. The default is unlimi
 A space-separated list of types to exclude from the analysis.
 
 .SS General Options
+.IP "-r, --reverse"
+Display information flows into the source type. No effect if a target type is specified.
 .IP "--stats"
 Print information flow graph statistics at the end of the analysis.
 .IP "-h, --help"

--- a/man/seinfoflow.1
+++ b/man/seinfoflow.1
@@ -67,10 +67,10 @@ Enable debugging output.
 
 .SH EXAMPLE
 .nf
-Show the shortest paths for process running as httpd_t to access user home files, using permission map from /var/lib/sepolgen/perm_map
-# seinfoflow -m /var/lib/sepolgen/perm_map -s httpd_t -t user_home_t -S
+Show the shortest paths for process running as httpd_t to access user home files, using the default permission map:
+# seinfoflow -s httpd_t -t user_home_t -S
 List all data paths shorter than 3 steps from smbd_t to httpd_log_t, when samba_enable_home_dirs and samba_create_home_dirs booleans are enabled
-# seinfoflow -m /var/lib/sepolgen/perm_map -s smbd_t -t user_home_t -A 3 -b "samba_enable_home_dirs:true,samba_create_home_dirs:true"
+# seinfoflow -s smbd_t -t user_home_t -A 3 -b "samba_enable_home_dirs:true,samba_create_home_dirs:true"
 
 .SH AUTHOR
 Chris PeBenito <pebenito@ieee.org>

--- a/seinfoflow
+++ b/seinfoflow
@@ -43,6 +43,9 @@ alg.add_argument("-A", "--all_paths", type=int, metavar="MAX_STEPS",
                  help="Calculate all paths, with the specified maximum path length. (Expensive)")
 
 opts = parser.add_argument_group("Analysis options")
+opts.add_argument("-r", "--reverse", action="store_false",
+                  help="Display information flows into the source type. "
+                  "No effect if a target type is specified.")
 opts.add_argument("-w", "--min_weight", default=3, type=int,
                   help="Minimum permission weight.  Default is 3.")
 opts.add_argument("-l", "--limit_flows", default=0, type=int,
@@ -126,7 +129,7 @@ try:
 
     else:  # single direct info flow
         flownum = 0
-        for flownum, flow in enumerate(g.infoflows(args.source), start=1):
+        for flownum, flow in enumerate(g.infoflows(args.source, out=args.reverse), start=1):
             print("Flow {0}: {1} -> {2}".format(flownum, flow.source, flow.target))
 
             if args.full:


### PR DESCRIPTION
Also remove references to the sepolgen permission map from the seinfoflow man page.