### PR TITLE
SELinuxPolicy: Add explicit cast for libspol message callback.

### DIFF
--- a/setools/policyrep/selinuxpolicy.pxi
+++ b/setools/policyrep/selinuxpolicy.pxi
@@ -668,7 +668,7 @@ cdef class SELinuxPolicy:
         if self.sh == NULL:
             raise MemoryError
 
-        sepol.sepol_msg_set_callback(self.sh, sepol_logging_callback, self.handle)
+        sepol.sepol_msg_set_callback(self.sh, <sepol.msg_callback>sepol_logging_callback, self.handle)
 
         if sepol.sepol_policydb_create(&self.handle) < 0:
             raise MemoryError

--- a/setools/policyrep/sepol.pxd
+++ b/setools/policyrep/sepol.pxd
@@ -16,8 +16,10 @@ cdef extern from "<sepol/handle.h>":
     void sepol_handle_destroy(sepol_handle_t *sh)
 
 
+ctypedef void (*msg_callback)(void *varg, sepol_handle_t *handle, const char *fmt, ...)
+
+
 cdef extern from "<sepol/debug.h>":
-    ctypedef void (*msg_callback)(void *varg, sepol_handle_t *handle, const char *fmt, ...)
     void sepol_msg_set_callback(sepol_handle * handle, msg_callback cb, void *cb_arg)
 
 


### PR DESCRIPTION
Cython 3.0 is more strict.  The change fixes this issue:
```
setools/policyrep/selinuxpolicy.pxi:685:46: Cannot assign type 'void (void *, sepol_handle_t *, const char *, ...) except *' to 'msg_callback'
```
Additionally, the msg_callback is not typedef-ed in `sepol/debug.h`, so it must be explicitly defined in `sepol.pxd` for the casting to work.