### PR TITLE
Update bit type

### DIFF
--- a/setools/policyrep/selinuxpolicy.pxi
+++ b/setools/policyrep/selinuxpolicy.pxi
@@ -935,8 +935,7 @@ cdef class SELinuxPolicy:
         """
 
         cdef:
-            size_t i, count
-            int bit
+            size_t bit, i, count
             sepol.ebitmap_node_t *node = NULL
             sepol.type_datum_t *tmp_type
             char *tmp_name


### PR DESCRIPTION
Avoid potential truncations and compiler warnings:

    setools/policyrep.c: In function ‘__pyx_f_7setools_9policyrep_13SELinuxPolicy__rebuild_attrs_from_map’:
    setools/policyrep.c:88248:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
    88248 |       __pyx_t_7 = ((__pyx_v_bit < ebitmap_length((&(__pyx_v_self->handle->p.attr_type_map[__pyx_v_i])))) != 0);
          |                                 ^
    setools/policyrep.c:88356:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
    88356 |       __pyx_t_7 = ((__pyx_v_bit < ebitmap_length((&__pyx_v_tmp_type->types))) != 0);
          |                                 ^