### PR TITLE
Update for libsepol 3.6

### DIFF
--- a/setools/policyrep/boolcond.pxi
+++ b/setools/policyrep/boolcond.pxi
@@ -333,7 +333,7 @@ cdef class ConditionalExprIterator(PolicyIterator):
 
         if self.curr.expr_type == sepol.COND_BOOL:
             item = Boolean.factory(self.policy,
-                                   self.policy.boolean_value_to_datum(self.curr.bool - 1))
+                                   self.policy.boolean_value_to_datum(self.curr.boolean - 1))
         else:
             item = ConditionalOperator.factory(self.policy, self.curr)
 

--- a/setools/policyrep/sepol.pxd
+++ b/setools/policyrep/sepol.pxd
@@ -283,6 +283,14 @@ cdef extern from "<sepol/policydb/sidtab.h>":
 
 
 cdef extern from "<sepol/policydb/conditional.h>":
+    """
+    #if defined(COND_EXPR_T_RENAME_BOOL_BOOLEAN)
+      #define COND_EXPR_T_RENAME_BOOL_NAME boolean
+    #else
+      #define COND_EXPR_T_RENAME_BOOL_NAME bool
+    #endif
+    """
+
     cdef int COND_EXPR_MAXDEPTH
     cdef int COND_MAX_BOOLS
 
@@ -309,7 +317,7 @@ cdef extern from "<sepol/policydb/conditional.h>":
 
     cdef struct cond_expr:
         uint32_t expr_type
-        uint32_t bool
+        uint32_t boolean "COND_EXPR_T_RENAME_BOOL_NAME"
         cond_expr *next
 
     ctypedef cond_expr cond_expr_t


### PR DESCRIPTION
In libsepol 3.6 the member name holding the value of the struct `cond_expr_t` has been changed from `bool` to `boolean`.

Check on the availability macro to support building against older and newer libsepol versions.

Fixes: #110