### PR TITLE
policyrep: Callback for C code should be noexcept

### DIFF
--- a/setools/policyrep/util.pxi
+++ b/setools/policyrep/util.pxi
@@ -75,7 +75,7 @@ class WeakKeyDefaultDict(weakref.WeakKeyDictionary):
 #
 # Functions
 #
-cdef void sepol_logging_callback(void *varg, sepol.sepol_handle_t * sh, const char *fmt, ...):
+cdef void sepol_logging_callback(void *varg, sepol.sepol_handle_t * sh, const char *fmt, ...) noexcept:
     """Python logging for sepol log callback."""
     cdef:
         va_list args


### PR DESCRIPTION
Compiling locally can cause:
```
Compiling setools/policyrep.pyx because it changed.
[1/1] Cythonizing setools/policyrep.pyx

Error compiling Cython file:
------------------------------------------------------------
...

        self.sh = sepol.sepol_handle_create()
        if self.sh == NULL:
            raise MemoryError

        sepol.sepol_msg_set_callback(self.sh, sepol_logging_callback, self.handle)
                                              ^
------------------------------------------------------------

setools/policyrep/selinuxpolicy.pxi:671:46: Cannot assign type 'void (void *, sepol_handle_t *, const char *, ...) except *' to 'msg_callback'. Exception values are incompatible. Suggest adding 'noexcept' to type 'void (void *, sepol_handle_t *, const char *, ...) except *'.
Traceback (most recent call last):
  File "setools/setup.py", line 162, in <module>
    ext_modules=cythonize(ext_py_mods, include_path=['setools/policyrep'],
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```