### PR TITLE
Make networkx optional again (Fixes #125)

### DIFF
--- a/setools/__init__.py
+++ b/setools/__init__.py
@@ -76,12 +76,15 @@ from .pirqconquery import PirqconQuery
 from .pcideviceconquery import PcideviceconQuery
 from .devicetreeconquery import DevicetreeconQuery
 
-# Information Flow Analysis
-from .infoflow import *
+# Information Flow and Domain Transition Analysis
+try:
+    import networkx
+except ImportError:
+    logging.getLogger(__name__).debug("NetworkX failed to import, disabling infoflow and dta.")
+else:
+    from .infoflow import *
+    from .dta import *
 from .permmap import PermissionMap, RuleWeight, Mapping
-
-# Domain Transition Analysis
-from .dta import *
 
 # Policy difference
 from .diff import PolicyDifference

--- a/setools/dta.py
+++ b/setools/dta.py
@@ -12,12 +12,8 @@ from contextlib import suppress
 from dataclasses import dataclass, InitVar
 import typing
 
-try:
-    import networkx as nx
-    from networkx.exception import NetworkXError, NetworkXNoPath, NodeNotFound
-
-except ImportError as iex:
-    logging.getLogger(__name__).debug(f"{iex.name} failed to import.")
+import networkx as nx
+from networkx.exception import NetworkXError, NetworkXNoPath, NodeNotFound
 
 from . import exception, mixins, policyrep, query
 from .descriptors import CriteriaDescriptor, EdgeAttrDict, EdgeAttrList

--- a/setools/infoflow.py
+++ b/setools/infoflow.py
@@ -10,12 +10,8 @@ from contextlib import suppress
 from dataclasses import dataclass, InitVar
 import typing
 
-try:
-    import networkx as nx
-    from networkx.exception import NetworkXError, NetworkXNoPath, NodeNotFound
-
-except ImportError as iex:
-    logging.getLogger(__name__).debug(f"{iex.name} failed to import.")
+import networkx as nx
+from networkx.exception import NetworkXError, NetworkXNoPath, NodeNotFound
 
 from . import exception, mixins, permmap, policyrep, query
 from .descriptors import CriteriaDescriptor, EdgeAttrIntMax, EdgeAttrList


### PR DESCRIPTION
The 5.6.0 update contains a refactoring, which makes the networkx dependency necessary again for other commands, such as sesearch and seinfo. This leads to issues when packaging for distributions that do not provide networkx and want to use setools in a minimal fashion.