### PR TITLE
Correct inclusion of parentheses when outputing constraints

### DIFF
--- a/tests/library/constraintquery.conf
+++ b/tests/library/constraintquery.conf
@@ -21,6 +21,8 @@ class test41b
 class test50
 class test51a
 class test51b
+class test52a
+class test52b
 
 sid kernel
 sid security
@@ -121,6 +123,12 @@ class test51a
 inherits test
 
 class test51b
+inherits test
+
+class test52a
+inherits test
+
+class test52b
 inherits test
 
 sensitivity low_s;
@@ -276,6 +284,16 @@ constrain test50 hi_w (u1 == u2 or u1 == test50u);
 # user: test51u. regex
 constrain test51a hi_w (u1 == u2 or u1 == test51u1);
 constrain test51b hi_w (u1 == u2 or u2 == test51u2);
+
+# test 52:
+# ruletype: unset
+# tclass: unset
+# perms: unset
+# role: unset
+# type: unset
+# user: unset
+constrain test52a hi_w ((r1 == system or r2 == system) and u1 == u2);
+constrain test52b hi_w (r1 == system or r2 == system and u1 == u2);
 
 #isids
 sid kernel system:system:system:medium_s:here

--- a/tests/library/test_constraintquery.py
+++ b/tests/library/test_constraintquery.py
@@ -1,4 +1,5 @@
 # Copyright 2015, Tresys Technology, LLC
+# Copyright 2024, Sealing Technologies, Inc.
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
@@ -94,3 +95,17 @@ class TestConstraintQuery:
 
         constraint = sorted(c.tclass for c in q.results())
         assert ["test51a", "test51b"] == constraint
+
+    def test_or_and_parens(self, compiled_policy: setools.SELinuxPolicy) -> None:
+        """Constraint with an or expression anded with another expression"""
+        q = setools.ConstraintQuery(compiled_policy, tclass=["test52a"])
+
+        constraint = sorted(str(c.expression) for c in q.results())
+        assert ["( r1 == system or r2 == system ) and u1 == u2"] == constraint
+
+    def test_or_and_no_parens(self, compiled_policy: setools.SELinuxPolicy) -> None:
+        """Constraint with an or expression anded with another expression"""
+        q = setools.ConstraintQuery(compiled_policy, tclass=["test52b"])
+
+        constraint = sorted(str(c.expression) for c in q.results())
+        assert ["r1 == system or r2 == system and u1 == u2"] == constraint


### PR DESCRIPTION
The existing algorithm to convert constraints from postfix to infix notation does not insert parentheses correctly. This change addresses the problem.

For example, given the following expression in the source policy:
( t2 == ssh_client_packet_t or t2 == ssh_server_packet_t ) and t1 == sshd_t

The output currently returned would be:
t2 == ssh_client_packet_t or ( t2 == ssh_server_packet_t ) and ( t1 == sshd_t )

Which of course is not equivalent to the actual expression due to the lack of parentheses surrounding the "or" expression.