### PR TITLE
tests: drop deprecated parameter

### DIFF
--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -17,7 +17,7 @@ except ImportError:
     have_pqtestqt = False
 
 
-def pytest_ignore_collect(collection_path: pathlib.Path, path,
+def pytest_ignore_collect(collection_path: pathlib.Path,
                           config: pytest.Config) -> bool | None:
 
     """Ignore GUI tests if DISPLAY is not set or PyQt is not available."""


### PR DESCRIPTION
    tests/gui/conftest.py:20
      setools/tests/gui/conftest.py:20: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (collection_path: pathlib.Path)
      see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
        def pytest_ignore_collect(collection_path: pathlib.Path, path,

    -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html