### PR TITLE
Remove redundant runtime requirement on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = ["Development Status :: 5 - Production/Stable",
 
 requires-python=">=3.10"
 # also requires libsepol.so and libselinux.so.
-dependencies = ["setuptools"]
+dependencies = []
 
 optional-dependencies.analysis = ["networkx>=2.6",
                                   "pygraphviz"]


### PR DESCRIPTION
The dependency was dropped in 99a1cf3b50cd8bf502b5070293c4d1bf792d1566