### PR TITLE
Remove redundant runtime requirement on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = ["Development Status :: 5 - Production/Stable",
 
 requires-python=">=3.10"
 # also requires libsepol.so and libselinux.so.
-dependencies = ["setuptools"]
+dependencies = []
 
 optional-dependencies.analysis = ["networkx>=2.6",
                                   "pygraphviz"]

--- a/tox.ini
+++ b/tox.ini
@@ -56,5 +56,6 @@ deps            = networkx>=2.6
                   pygraphviz
                   pytest-qt
                   pytest-xvfb
+                  setuptools;python_version>="3.12"
 commands_pre    = {envpython} setup.py build_ext -i
 commands        = {envpython} -m pytest tests


### PR DESCRIPTION
The dependency was dropped in 99a1cf3b50cd8bf502b5070293c4d1bf792d1566

Add a build time dependency for setup.py build_ext on Python 3.12+ which no longer contains distutils.