### PR TITLE
Fix seinfo argument parsing when policy path follows query options

### DIFF
--- a/seinfo
+++ b/seinfo
@@ -12,6 +12,7 @@ import logging
 import signal
 import ipaddress
 import warnings
+from pathlib import Path
 from typing import Callable, List, Tuple
 
 
@@ -101,6 +102,18 @@ xen.add_argument("--devicetreecon", help="Print all devicetreecon statements.",
 
 
 args = parser.parse_args()
+
+# Fix argument misparsing: when policy is None and a query option is a string,
+# check if the string is actually a policy file that is incorrectly consumed by the query option
+if not args.policy:
+    # Check all query options defined in the queries argument group
+    for action in queries._group_actions:
+        value = getattr(args, action.dest, None)
+        if isinstance(value, str) and Path(value).exists():
+            # This query argument consumed the policy path - fix it
+            args.policy = value
+            setattr(args, action.dest, True)
+            break
 
 if args.debug:
     logging.basicConfig(level=logging.DEBUG,


### PR DESCRIPTION
When we run commands with flags/options that can optionally take argument value like -t, -r, etc. along with policy file. It breaks the behavior because the entire policy file path is wrongly taken as value for the argument before it.

seinfo -t /path/to/policy.33  -> will take /path/to/policy.33 as string argument for -t and show 0 results, when it should show all types without any string argument filtering from the policy.

The workaround is 
seinfo /path/to/policy.33 -t

I have added a fix to ensure the we check the argument followed by any of the args in 'queries' when args.policy is not detected already. Then verify the next argument is a valid path , if yes then add it to args.policy otherwise it's an argument value. Since there are not args which actually take a path, my fix should work properly. 
I have tested it for -t with policy, without policy , with value and policy, with value and no policy. Similarly have tested -r and -a for all 4 combinations. 
