### PR TITLE
Seinfo improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     # This should be the minimum required Python version to build refpolicy.
     - name: Set up Python ${{ matrix.build-opts.python }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.build-opts.python }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           - {python: '3.10', tox: python3}
           - {python: '3.11', tox: python3}
           - {python: '3.12', tox: python3}
+          - {python: '3.13', tox: python3}
           - {python: '3.11', tox: pep8}
           - {python: '3.11', tox: lint}
           - {python: '3.11', tox: mypy}

--- a/seinfo
+++ b/seinfo
@@ -107,6 +107,13 @@ xen.add_argument("--devicetreecon", help="Print all devicetreecon statements.",
 
 args = parser.parse_args()
 
+# SELinux-specific args and Xen-specific args cannot be combined
+sel_args = ["/".join(a.option_strings) for a in selinux._group_actions if getattr(args, a.dest)]
+xen_args = ["/".join(a.option_strings) for a in xen._group_actions if getattr(args, a.dest)]
+if sel_args and xen_args:
+    parser.error(f"SELinux arguments ({', '.join(sel_args)}) cannot be combined with "
+                 f"Xen arguments ({', '.join(xen_args)}).")
+
 # Fix argument misparsing: when policy is None and a query option is a string,
 # check if the string is actually a policy file that is incorrectly consumed by the query option
 if not args.policy:
@@ -136,6 +143,14 @@ else:
 try:
     p = setools.SELinuxPolicy(args.policy)
     components: List[Tuple[str, setools.PolicyQuery, Callable]] = []
+    if p.target_platform == setools.PolicyTarget.selinux:
+        if xen_args:
+            raise RuntimeError(f"error: Xen queries specified ({', '.join(xen_args)}), but "
+                               f"{p} is an SELinux policy.")
+    elif p.target_platform == setools.PolicyTarget.xen:
+        if sel_args:
+            raise RuntimeError(f"error: SELinux queries specified ({', '.join(sel_args)}), but "
+                               f"{p} is a Xen policy.")
 
     if args.boolquery or args.all:
         bq = setools.BoolQuery(p)

--- a/seinfo
+++ b/seinfo
@@ -94,15 +94,15 @@ selinux.add_argument("--portcon", help="Print portcon statements.", dest="portco
 
 xen = parser.add_argument_group("Xen-specific Queries")
 xen.add_argument("--devicetreecon", help="Print all devicetreecon statements.",
-                 dest="devicetreeconquery", default=False, action="store_true")
+                 dest="devicetreeconquery", nargs='?', const=True, metavar="PATH")
 xen.add_argument("--iomemcon", help="Print all iomemcon statements.", dest="iomemconquery",
-                 default=False, action="store_true")
+                 nargs='?', const=True, metavar="ADDR[-ADDR]")
 xen.add_argument("--ioportcon", help="Print all ioportcon statements.", dest="ioportconquery",
-                 default=False, action="store_true")
+                 nargs='?', const=True, metavar="PORTNUM[-PORTNUM]")
 xen.add_argument("--pcidevicecon", help="Print all pcidevicecon statements.",
-                 dest="pcideviceconquery", default=False, action="store_true")
+                 dest="pcideviceconquery", nargs='?', const=True, metavar="DEVICE")
 xen.add_argument("--pirqcon", help="Print all pirqcon statements.", dest="pirqconquery",
-                 default=False, action="store_true")
+                 nargs='?', const=True, metavar="IRQ")
 
 
 args = parser.parse_args()
@@ -352,22 +352,57 @@ try:
     elif p.target_platform == setools.PolicyTarget.xen:
         if args.devicetreeconquery or args.all:
             dtq = setools.DevicetreeconQuery(p)
+            if isinstance(args.devicetreeconquery, str):
+                dtq.path = args.devicetreeconquery
+
             components.append(("Devicetreecon", dtq, lambda x: x.statement()))
 
         if args.iomemconquery or args.all:
             xiomq = setools.IomemconQuery(p)
+            if isinstance(args.iomemconquery, str):
+                try:
+                    ports = [int(i, base=16) for i in args.iomemconquery.split("-")]
+                except ValueError:
+                    parser.error("Enter an IO memory address or range, e.g. 0x22 or 0x6000-0x6020")
+
+                if len(ports) == 2:
+                    xiomq.addr = setools.IomemconRange(*ports)
+                elif len(ports) == 1:
+                    xiomq.addr = setools.IomemconRange(ports[0], ports[0])
+                else:
+                    parser.error("Enter an IO memory address or range, e.g. 0x22 or 0x6000-0x6020")
+
             components.append(("Iomemcon", xiomq, lambda x: x.statement()))
 
         if args.ioportconquery or args.all:
-            xiopq = setools.IoportconQuery(p)
+            xiopq = setools.IoportconQuery(p, ports_subset=True)
+            if isinstance(args.ioportconquery, str):
+                try:
+                    ports = [int(i, base=16) for i in args.ioportconquery.split("-")]
+                except ValueError:
+                    parser.error("Enter an IO port number or range, e.g. 0x22 or 0x6000-0x6020")
+
+                if len(ports) == 2:
+                    xiopq.ports = setools.IoportconRange(*ports)
+                elif len(ports) == 1:
+                    xiopq.ports = setools.IoportconRange(ports[0], ports[0])
+                else:
+                    parser.error("Enter an IO port number or range, e.g. 0x22 or 0x6000-0x6020")
+
             components.append(("Ioportcon", xiopq, lambda x: x.statement()))
 
         if args.pcideviceconquery or args.all:
             pcidq = setools.PcideviceconQuery(p)
+            if isinstance(args.pcideviceconquery, str):
+                pcidq.device = int(args.pcideviceconquery, base=16)
+
             components.append(("Pcidevicecon", pcidq, lambda x: x.statement()))
 
         if args.pirqconquery or args.all:
             pirqq = setools.PirqconQuery(p)
+            if isinstance(args.pirqconquery, str):
+                pirqq.irq = int(args.pirqconquery)
+
             components.append(("Pirqcon", pirqq, lambda x: x.statement()))
 
     if (not components or args.all) and not args.flat:

--- a/seinfo
+++ b/seinfo
@@ -5,15 +5,17 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-import setools
 import argparse
 import sys
 import logging
 import signal
 import ipaddress
 import warnings
+from itertools import chain
 from pathlib import Path
 from typing import Callable, List, Tuple
+
+import setools
 
 
 def expand_attr(attr):
@@ -57,26 +59,10 @@ queries.add_argument("--constrain", help="Print constraints.", dest="constraintq
                      nargs='?', const=True, metavar="CLASS")
 queries.add_argument("--default", help="Print default_* rules.", dest="defaultquery",
                      nargs='?', const=True, metavar="CLASS")
-queries.add_argument("--fs_use", help="Print fs_use statements.", dest="fsusequery",
-                     nargs='?', const=True, metavar="FS_TYPE")
-queries.add_argument("--genfscon", help="Print genfscon statements.", dest="genfsconquery",
-                     nargs='?', const=True, metavar="FS_TYPE")
-queries.add_argument("--ibpkeycon", help="Infiniband pkey statements.",
-                     dest="ibpkeyconquery", nargs='?', const=True, metavar="PKEY[-PKEY]")
-queries.add_argument("--ibendportcon", help="Infiniband endport statements.",
-                     dest="ibendportconquery", nargs='?', const=True, metavar="NAME")
-queries.add_argument("--initialsid", help="Print initial SIDs (contexts).", dest="initialsidquery",
-                     nargs='?', const=True, metavar="NAME")
-queries.add_argument("--netifcon", help="Print netifcon statements.", dest="netifconquery",
-                     nargs='?', const=True, metavar="DEVICE")
-queries.add_argument("--nodecon", help="Print nodecon statements.", dest="nodeconquery",
-                     nargs='?', const=True, metavar="ADDR")
 queries.add_argument("--permissive", help="Print permissive types.", dest="permissivequery",
                      nargs='?', const=True, metavar="TYPE")
 queries.add_argument("--polcap", help="Print policy capabilities.", dest="polcapquery",
                      nargs='?', const=True, metavar="NAME")
-queries.add_argument("--portcon", help="Print portcon statements.", dest="portconquery",
-                     nargs='?', const=True, metavar="PORTNUM[-PORTNUM]")
 queries.add_argument("--role_types", help="Print all roles associated with the given type.",
                      dest="roletypesquery", nargs=1, metavar="TYPE")
 queries.add_argument("--sensitivity", help="Print MLS sensitivities.", dest="mlssensquery",
@@ -88,7 +74,25 @@ queries.add_argument("--validatetrans", help="Print validatetrans.", dest="valid
 queries.add_argument("--all", help="Print all of the above.  On a Xen policy, the Xen components "
                      "will also be printed", dest="all", default=False, action="store_true")
 
-xen = parser.add_argument_group("Xen Component Queries")
+selinux = parser.add_argument_group("SELinux-specific Queries")
+selinux.add_argument("--fs_use", help="Print fs_use statements.", dest="fsusequery",
+                     nargs='?', const=True, metavar="FS_TYPE")
+selinux.add_argument("--genfscon", help="Print genfscon statements.", dest="genfsconquery",
+                     nargs='?', const=True, metavar="FS_TYPE")
+selinux.add_argument("--ibpkeycon", help="Infiniband pkey statements.",
+                     dest="ibpkeyconquery", nargs='?', const=True, metavar="PKEY[-PKEY]")
+selinux.add_argument("--ibendportcon", help="Infiniband endport statements.",
+                     dest="ibendportconquery", nargs='?', const=True, metavar="NAME")
+selinux.add_argument("--initialsid", help="Print initial SIDs (contexts).", dest="initialsidquery",
+                     nargs='?', const=True, metavar="NAME")
+selinux.add_argument("--netifcon", help="Print netifcon statements.", dest="netifconquery",
+                     nargs='?', const=True, metavar="DEVICE")
+selinux.add_argument("--nodecon", help="Print nodecon statements.", dest="nodeconquery",
+                     nargs='?', const=True, metavar="ADDR")
+selinux.add_argument("--portcon", help="Print portcon statements.", dest="portconquery",
+                     nargs='?', const=True, metavar="PORTNUM[-PORTNUM]")
+
+xen = parser.add_argument_group("Xen-specific Queries")
 xen.add_argument("--ioportcon", help="Print all ioportcon statements.", dest="ioportconquery",
                  default=False, action="store_true")
 xen.add_argument("--iomemcon", help="Print all iomemcon statements.", dest="iomemconquery",
@@ -107,7 +111,7 @@ args = parser.parse_args()
 # check if the string is actually a policy file that is incorrectly consumed by the query option
 if not args.policy:
     # Check all query options defined in the queries argument group
-    for action in queries._group_actions:
+    for action in chain(queries._group_actions, selinux._group_actions, xen._group_actions):
         value = getattr(args, action.dest, None)
         if isinstance(value, str) and Path(value).exists():
             # This query argument consumed the policy path - fix it
@@ -181,65 +185,6 @@ try:
 
         components.append(("Default rules", dq, lambda x: x.statement()))
 
-    if args.fsusequery or args.all:
-        fq: setools.FSUseQuery = setools.FSUseQuery(p)
-        if isinstance(args.fsusequery, str):
-            fq.fs = args.fsusequery
-
-        components.append(("Fs_use", fq, lambda x: x.statement()))
-
-    if args.genfsconquery or args.all:
-        gq: setools.GenfsconQuery = setools.GenfsconQuery(p)
-        if isinstance(args.genfsconquery, str):
-            gq.fs = args.genfsconquery
-
-        components.append(("Genfscon", gq, lambda x: x.statement()))
-
-    if args.ibendportconquery or args.all:
-        ibepq: setools.IbendportconQuery = setools.IbendportconQuery(p)
-        if isinstance(args.ibendportconquery, str):
-            ibepq.name = args.ibendportconquery
-
-        components.append(("Ibendportcon", ibepq, lambda x: x.statement()))
-
-    if args.ibpkeyconquery or args.all:
-        ibpkq = setools.IbpkeyconQuery(p)
-        if isinstance(args.ibpkeyconquery, str):
-            try:
-                pkeys = [int(i, 16) for i in args.ibpkeyconquery.split("-")]
-            except ValueError:
-                parser.error("Enter a pkey number or range, e.g. 0x22 or 0x6000-0x6020")
-
-            if len(pkeys) == 2:
-                ibpkq.pkeys = setools.IbpkeyconRange(*pkeys)
-            elif len(pkeys) == 1:
-                ibpkq.pkeys = setools.IbpkeyconRange(pkeys[0], pkeys[0])
-            else:
-                parser.error("Enter a pkey number or range, e.g. 0x22 or 0x6000-0x6020")
-
-        components.append(("Ibpkeycon", ibpkq, lambda x: x.statement()))
-
-    if args.initialsidquery or args.all:
-        isidq = setools.InitialSIDQuery(p)
-        if isinstance(args.initialsidquery, str):
-            isidq.name = args.initialsidquery
-
-        components.append(("Initial SIDs", isidq, lambda x: x.statement()))
-
-    if args.netifconquery or args.all:
-        netifq = setools.NetifconQuery(p)
-        if isinstance(args.netifconquery, str):
-            netifq.name = args.netifconquery
-
-        components.append(("Netifcon", netifq, lambda x: x.statement()))
-
-    if args.nodeconquery or args.all:
-        nodeq = setools.NodeconQuery(p)
-        if isinstance(args.nodeconquery, str):
-            nodeq.network = ipaddress.ip_network(args.nodeconquery)
-
-        components.append(("Nodecon", nodeq, lambda x: x.statement()))
-
     if args.permissivequery or args.all:
         permq = setools.TypeQuery(p, permissive=True, match_permissive=True)
         if isinstance(args.permissivequery, str):
@@ -253,23 +198,6 @@ try:
             capq.name = args.polcapquery
 
         components.append(("Polcap", capq, lambda x: x.statement()))
-
-    if args.portconquery or args.all:
-        pcq = setools.PortconQuery(p, ports_subset=True)
-        if isinstance(args.portconquery, str):
-            try:
-                ports = [int(i) for i in args.portconquery.split("-")]
-            except ValueError:
-                parser.error("Enter a port number or range, e.g. 22 or 6000-6020")
-
-            if len(ports) == 2:
-                pcq.ports = setools.PortconRange(*ports)
-            elif len(ports) == 1:
-                pcq.ports = setools.PortconRange(ports[0], ports[0])
-            else:
-                parser.error("Enter a port number or range, e.g. 22 or 6000-6020")
-
-        components.append(("Portcon", pcq, lambda x: x.statement()))
 
     if args.rolequery or args.all:
         rq = setools.RoleQuery(p)
@@ -329,14 +257,95 @@ try:
 
         components.append(("Validatetrans", vtq, lambda x: x.statement()))
 
-    if p.target_platform == setools.PolicyTarget.xen:
-        if args.ioportconquery or args.all:
-            xiopq = setools.IoportconQuery(p)
-            components.append(("Ioportcon", xiopq, lambda x: x.statement()))
+    if p.target_platform == setools.PolicyTarget.selinux:
+        if args.fsusequery or args.all:
+            fq: setools.FSUseQuery = setools.FSUseQuery(p)
+            if isinstance(args.fsusequery, str):
+                fq.fs = args.fsusequery
+
+            components.append(("Fs_use", fq, lambda x: x.statement()))
+
+        if args.genfsconquery or args.all:
+            gq: setools.GenfsconQuery = setools.GenfsconQuery(p)
+            if isinstance(args.genfsconquery, str):
+                gq.fs = args.genfsconquery
+
+            components.append(("Genfscon", gq, lambda x: x.statement()))
+
+        if args.ibendportconquery or args.all:
+            ibepq: setools.IbendportconQuery = setools.IbendportconQuery(p)
+            if isinstance(args.ibendportconquery, str):
+                ibepq.name = args.ibendportconquery
+
+            components.append(("Ibendportcon", ibepq, lambda x: x.statement()))
+
+        if args.ibpkeyconquery or args.all:
+            ibpkq = setools.IbpkeyconQuery(p)
+            if isinstance(args.ibpkeyconquery, str):
+                try:
+                    pkeys = [int(i, 16) for i in args.ibpkeyconquery.split("-")]
+                except ValueError:
+                    parser.error("Enter a pkey number or range, e.g. 0x22 or 0x6000-0x6020")
+
+                if len(pkeys) == 2:
+                    ibpkq.pkeys = setools.IbpkeyconRange(*pkeys)
+                elif len(pkeys) == 1:
+                    ibpkq.pkeys = setools.IbpkeyconRange(pkeys[0], pkeys[0])
+                else:
+                    parser.error("Enter a pkey number or range, e.g. 0x22 or 0x6000-0x6020")
+
+            components.append(("Ibpkeycon", ibpkq, lambda x: x.statement()))
+
+        if args.initialsidquery or args.all:
+            isidq = setools.InitialSIDQuery(p)
+            if isinstance(args.initialsidquery, str):
+                isidq.name = args.initialsidquery
+
+            components.append(("Initial SIDs", isidq, lambda x: x.statement()))
+
+        if args.netifconquery or args.all:
+            netifq = setools.NetifconQuery(p)
+            if isinstance(args.netifconquery, str):
+                netifq.name = args.netifconquery
+
+            components.append(("Netifcon", netifq, lambda x: x.statement()))
+
+        if args.nodeconquery or args.all:
+            nodeq = setools.NodeconQuery(p)
+            if isinstance(args.nodeconquery, str):
+                nodeq.network = ipaddress.ip_network(args.nodeconquery)
+
+            components.append(("Nodecon", nodeq, lambda x: x.statement()))
+
+        if args.portconquery or args.all:
+            pcq = setools.PortconQuery(p, ports_subset=True)
+            if isinstance(args.portconquery, str):
+                try:
+                    ports = [int(i) for i in args.portconquery.split("-")]
+                except ValueError:
+                    parser.error("Enter a port number or range, e.g. 22 or 6000-6020")
+
+                if len(ports) == 2:
+                    pcq.ports = setools.PortconRange(*ports)
+                elif len(ports) == 1:
+                    pcq.ports = setools.PortconRange(ports[0], ports[0])
+                else:
+                    parser.error("Enter a port number or range, e.g. 22 or 6000-6020")
+
+            components.append(("Portcon", pcq, lambda x: x.statement()))
+
+    elif p.target_platform == setools.PolicyTarget.xen:
+        if args.devicetreeconquery or args.all:
+            dtq = setools.DevicetreeconQuery(p)
+            components.append(("Devicetreecon", dtq, lambda x: x.statement()))
 
         if args.iomemconquery or args.all:
             xiomq = setools.IomemconQuery(p)
             components.append(("Iomemcon", xiomq, lambda x: x.statement()))
+
+        if args.ioportconquery or args.all:
+            xiopq = setools.IoportconQuery(p)
+            components.append(("Ioportcon", xiopq, lambda x: x.statement()))
 
         if args.pcideviceconquery or args.all:
             pcidq = setools.PcideviceconQuery(p)
@@ -345,10 +354,6 @@ try:
         if args.pirqconquery or args.all:
             pirqq = setools.PirqconQuery(p)
             components.append(("Pirqcon", pirqq, lambda x: x.statement()))
-
-        if args.devicetreeconquery or args.all:
-            dtq = setools.DevicetreeconQuery(p)
-            components.append(("Devicetreecon", dtq, lambda x: x.statement()))
 
     if (not components or args.all) and not args.flat:
         mls = "enabled" if p.mls else "disabled"

--- a/seinfo
+++ b/seinfo
@@ -93,16 +93,16 @@ selinux.add_argument("--portcon", help="Print portcon statements.", dest="portco
                      nargs='?', const=True, metavar="PORTNUM[-PORTNUM]")
 
 xen = parser.add_argument_group("Xen-specific Queries")
-xen.add_argument("--ioportcon", help="Print all ioportcon statements.", dest="ioportconquery",
-                 default=False, action="store_true")
+xen.add_argument("--devicetreecon", help="Print all devicetreecon statements.",
+                 dest="devicetreeconquery", default=False, action="store_true")
 xen.add_argument("--iomemcon", help="Print all iomemcon statements.", dest="iomemconquery",
+                 default=False, action="store_true")
+xen.add_argument("--ioportcon", help="Print all ioportcon statements.", dest="ioportconquery",
                  default=False, action="store_true")
 xen.add_argument("--pcidevicecon", help="Print all pcidevicecon statements.",
                  dest="pcideviceconquery", default=False, action="store_true")
 xen.add_argument("--pirqcon", help="Print all pirqcon statements.", dest="pirqconquery",
                  default=False, action="store_true")
-xen.add_argument("--devicetreecon", help="Print all devicetreecon statements.",
-                 dest="devicetreeconquery", default=False, action="store_true")
 
 
 args = parser.parse_args()

--- a/setools/devicetreeconquery.py
+++ b/setools/devicetreeconquery.py
@@ -44,6 +44,8 @@ class DevicetreeconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.xen
+
     path: str | None = None
 
     def results(self) -> Iterable[policyrep.Devicetreecon]:

--- a/setools/exception.py
+++ b/setools/exception.py
@@ -49,6 +49,16 @@ class MLSDisabled(PolicyrepException):
     pass
 
 
+class PlatformMismatch(ValueError, PolicyrepException):
+
+    """
+    Exception when the policy platform does not match the requested
+    platform.  For example a Xen policy is loaded, but a query
+    requiring SELinux is attempted.
+    """
+    pass
+
+
 #
 # Invalid component exceptions
 #

--- a/setools/fsusequery.py
+++ b/setools/fsusequery.py
@@ -44,6 +44,8 @@ class FSUseQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     ruletype = CriteriaSetDescriptor[policyrep.FSUseRuletype](enum_class=policyrep.FSUseRuletype)
     fs = CriteriaDescriptor[str]("fs_regex")
     fs_regex: bool = False

--- a/setools/genfsconquery.py
+++ b/setools/genfsconquery.py
@@ -46,6 +46,8 @@ class GenfsconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     filetype: int | None = None
     fs = CriteriaDescriptor[str]("fs_regex")
     fs_regex: bool = False

--- a/setools/ibendportconquery.py
+++ b/setools/ibendportconquery.py
@@ -43,6 +43,8 @@ class IbendportconQuery(mixins.MatchContext, mixins.MatchName, query.PolicyQuery
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     _port: int | None = None
 
     @property

--- a/setools/ibpkeyconquery.py
+++ b/setools/ibpkeyconquery.py
@@ -51,6 +51,8 @@ class IbpkeyconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     _subnet_prefix: IPv6Address | None = None
     _pkeys: policyrep.IbpkeyconRange | None = None
     pkeys_subset: bool = False

--- a/setools/initsidquery.py
+++ b/setools/initsidquery.py
@@ -42,6 +42,8 @@ class InitialSIDQuery(mixins.MatchName, mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     def results(self) -> Iterable[policyrep.InitialSID]:
         """Generator which yields all matching initial SIDs."""
         self.log.info(f"Generating initial SID results from {self.policy}")

--- a/setools/iomemconquery.py
+++ b/setools/iomemconquery.py
@@ -53,6 +53,8 @@ class IomemconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.xen
+
     _addr: policyrep.IomemconRange | None = None
     addr_subset: bool = False
     addr_overlap: bool = False

--- a/setools/iomemconquery.py
+++ b/setools/iomemconquery.py
@@ -66,11 +66,11 @@ class IomemconQuery(mixins.MatchContext, query.PolicyQuery):
         return self._addr
 
     @addr.setter
-    def addr(self, value: tuple[int, int] | None) -> None:
-        if value:
-            self._addr = policyrep.IomemconRange(*value)
+    def addr(self, value: policyrep.IomemconRange | tuple[int, int] | None) -> None:
+        if isinstance(value, policyrep.IomemconRange):
+            self._addr = value
         else:
-            self._addr = None
+            self._addr = policyrep.IomemconRange(*value) if value else None
 
     def results(self) -> Iterable[policyrep.Iomemcon]:
         """Generator which yields all matching iomemcons."""

--- a/setools/ioportconquery.py
+++ b/setools/ioportconquery.py
@@ -53,6 +53,8 @@ class IoportconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.xen
+
     _ports: policyrep.IoportconRange | None = None
     ports_subset: bool = False
     ports_overlap: bool = False

--- a/setools/ioportconquery.py
+++ b/setools/ioportconquery.py
@@ -66,11 +66,11 @@ class IoportconQuery(mixins.MatchContext, query.PolicyQuery):
         return self._ports
 
     @ports.setter
-    def ports(self, value: tuple[int, int] | None) -> None:
-        if value:
-            self._ports = policyrep.IoportconRange(*value)
+    def ports(self, value: policyrep.IoportconRange | tuple[int, int] | None) -> None:
+        if isinstance(value, policyrep.IoportconRange):
+            self._ports = value
         else:
-            self._ports = None
+            self._ports = policyrep.IoportconRange(*value) if value else None
 
     def results(self) -> Iterable[policyrep.Ioportcon]:
         """Generator which yields all matching ioportcons."""

--- a/setools/netifconquery.py
+++ b/setools/netifconquery.py
@@ -42,6 +42,8 @@ class NetifconQuery(mixins.MatchContext, mixins.MatchName, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     def results(self) -> Iterable[policyrep.Netifcon]:
         """Generator which yields all matching netifcons."""
         self.log.info(f"Generating netifcon results from {self.policy}")

--- a/setools/nodeconquery.py
+++ b/setools/nodeconquery.py
@@ -50,6 +50,8 @@ class NodeconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     _network: AnyIPNetwork | None = None
     network_overlap: bool = False
     _ip_version: policyrep.NodeconIPVersion | None = None

--- a/setools/pcideviceconquery.py
+++ b/setools/pcideviceconquery.py
@@ -44,6 +44,8 @@ class PcideviceconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.xen
+
     _device: int | None = None
 
     @property

--- a/setools/pirqconquery.py
+++ b/setools/pirqconquery.py
@@ -44,6 +44,8 @@ class PirqconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.xen
+
     _irq: int | None = None
 
     @property

--- a/setools/policyrep/netcontext.pxi
+++ b/setools/policyrep/netcontext.pxi
@@ -17,16 +17,19 @@ class IbpkeyconRange:
 
     def __post_init__(self):
         if self.low < IbpkeyconRange.MIN or self.high < IbpkeyconRange.MIN:
-            raise ValueError(
-                f"Pkeys must be >= {IbpkeyconRange.MIN:#x}: {self.low:#x}-{self.high:#x}")
+            raise ValueError(f"Partition keys must be >= {IbpkeyconRange.MIN:0=#6x}: {self}")
 
         if self.low > IbpkeyconRange.MAX or self.high > IbpkeyconRange.MAX:
-            raise ValueError(
-                f"Pkeys must be <= {IbpkeyconRange.MAX:#x}: {self.low:#x}-{self.high:#x}")
+            raise ValueError(f"Partition keys must be <= {IbpkeyconRange.MAX:0=#6x}: {self}")
 
         if self.low > self.high:
-            raise ValueError(
-                f"The low pkey must be <= the high pkey: {self.low:#x}-{self.high:#x}")
+            raise ValueError(f"The low partition key must be <= the high partition key: {self}")
+
+    def __str__(self):
+        if self.low == self.high:
+            return f"{self.low:0=#6x}"
+        else:
+            return f"{self.low:0=#6x}-{self.high:0=#6x}"
 
 
 @dataclasses.dataclass(eq=True, order=True, frozen=True)
@@ -42,14 +45,19 @@ class PortconRange:
 
     def __post_init__(self):
         if self.low < PortconRange.MIN or self.high < PortconRange.MIN:
-            raise ValueError(f"Port numbers must be >= {PortconRange.MIN}: {self.low}-{self.high}")
+            raise ValueError(f"Port numbers must be >= {PortconRange.MIN}: {self}")
 
         if self.low > PortconRange.MAX or self.high > PortconRange.MAX:
-            raise ValueError(f"Port numbers must be <= {PortconRange.MAX}: {self.low}-{self.high}")
+            raise ValueError(f"Port numbers must be <= {PortconRange.MAX}: {self}")
 
         if self.low > self.high:
-            raise ValueError(
-                f"The low port must be <= the high port: {self.low}-{self.high}")
+            raise ValueError(f"The low port must be <= the high port: {self}")
+
+    def __str__(self):
+        if self.low == self.high:
+            return str(self.low)
+        else:
+            return f"{self.low}-{self.high}"
 
 
 #
@@ -140,10 +148,7 @@ cdef class Ibpkeycon(Ocontext):
         return str(self) < str(other)
 
     def statement(self):
-        if self.pkeys.low == self.pkeys.high:
-            return f"ibpkeycon {self.subnet_prefix} {self.pkeys.low:#x} {self.context}"
-        else:
-            return f"ibpkeycon {self.subnet_prefix} {self.pkeys.low:#x}-{self.pkeys.high:#x} {self.context}"
+        return f"ibpkeycon {self.subnet_prefix} {self.pkeys} {self.context}"
 
 
 cdef class Netifcon(Ocontext):
@@ -316,12 +321,7 @@ cdef class Portcon(Ocontext):
         return str(self) < str(other)
 
     def statement(self):
-        low, high = self.ports.low, self.ports.high
-
-        if low == high:
-            return f"portcon {self.protocol} {low} {self.context}"
-        else:
-            return f"portcon {self.protocol} {low}-{high} {self.context}"
+        return f"portcon {self.protocol} {self.ports} {self.context}"
 
 
 #

--- a/setools/policyrep/selinuxpolicy.pxi
+++ b/setools/policyrep/selinuxpolicy.pxi
@@ -742,7 +742,7 @@ cdef class SELinuxPolicy:
             for version in range(max_ver, min_ver - 1, -1):
                 potential_policies.append(f"{base_policy_path}.{version}")
 
-        self.log.debug("Potential policies: {potential_policies}")
+        self.log.debug(f"Potential policies: {potential_policies}")
         for filename in potential_policies:
             try:
                 self._load_policy(filename)

--- a/setools/policyrep/xencontext.pxi
+++ b/setools/policyrep/xencontext.pxi
@@ -17,16 +17,19 @@ class IomemconRange:
 
     def __post_init__(self):
         if self.low < IomemconRange.MIN or self.high < IomemconRange.MIN:
-            raise ValueError(
-                f"Memory address must be >= {IomemconRange.MIN}: {self.low}-{self.high}")
+            raise ValueError(f"Memory address must be >= {IomemconRange.MIN:0=#6x}: {self}")
 
         if self.low > IomemconRange.MAX or self.high > IomemconRange.MAX:
-            raise ValueError(
-                f"Memory address must be <= {IomemconRange.MAX}: {self.low}-{self.high}")
+            raise ValueError(f"Memory address must be <= {IomemconRange.MAX:0=#6x}: {self}")
 
         if self.low > self.high:
-            raise ValueError(
-                f"The low mem addr must be smaller than the high mem addr: {self.low}-{self.high}")
+            raise ValueError(f"The low mem addr must be smaller than the high mem addr: {self}")
+
+    def __str__(self):
+        if self.low == self.high:
+            return f"{self.low:0=#6x}"
+        else:
+            return f"{self.low:0=#6x}-{self.high:0=#6x}"
 
 
 @dataclasses.dataclass(eq=True, order=True, frozen=True)
@@ -42,16 +45,20 @@ class IoportconRange:
 
     def __post_init__(self):
         if self.low < IoportconRange.MIN or self.high < IoportconRange.MIN:
-            raise ValueError(
-                f"Port numbers must be >= {IoportconRange.MIN}: {self.low}-{self.high}")
+            raise ValueError(f"Port numbers must be >= {IoportconRange.MIN:0=#6x}: {self}")
 
         if self.low > IoportconRange.MAX or self.high > IoportconRange.MAX:
-            raise ValueError(
-                f"Port numbers must be <= {IoportconRange.MAX}: {self.low}-{self.high}")
+            raise ValueError( f"Port numbers must be <= {IoportconRange.MAX:0=#6x}: {self}")
 
         if self.low > self.high:
-            raise ValueError("The low port must be smaller than the high port: "
-                f"{self.low}-{self.high}")
+            raise ValueError(f"The low port must be smaller than the high port: {self}")
+
+    def __str__(self):
+        if self.low == self.high:
+            return f"{self.low:0=#6x}"
+        else:
+            return f"{self.low:0=#6x}-{self.high:0=#6x}"
+
 
 #
 # Classes
@@ -93,12 +100,7 @@ cdef class Iomemcon(Ocontext):
         return i
 
     def statement(self):
-        low, high = self.addr.low, self.addr.high
-
-        if low == high:
-            return "iomemcon {low} {self.context1}"
-        else:
-            return "iomemcon {low}-{high} {self.context}"
+        return f"iomemcon {self.addr} {self.context}"
 
 
 cdef class Ioportcon(Ocontext):
@@ -118,12 +120,7 @@ cdef class Ioportcon(Ocontext):
         return i
 
     def statement(self):
-        low, high = self.ports.low, self.ports.high
-
-        if low == high:
-            return "ioportcon {low} {self.context}"
-        else:
-            return "ioportcon {low}-{high} {self.context}"
+        return f"ioportcon {self.ports} {self.context}"
 
 
 cdef class Pcidevicecon(Ocontext):
@@ -143,7 +140,7 @@ cdef class Pcidevicecon(Ocontext):
         return p
 
     def statement(self):
-        return f"pcidevicecon {self.device} {self.context}"
+        return f"pcidevicecon {self.device:0=#6x} {self.context}"
 
 
 cdef class Pirqcon(Ocontext):

--- a/setools/portconquery.py
+++ b/setools/portconquery.py
@@ -56,6 +56,8 @@ class PortconQuery(mixins.MatchContext, query.PolicyQuery):
                     No effect if not using set operations.
     """
 
+    required_platform = policyrep.PolicyTarget.selinux
+
     _protocol: policyrep.PortconProtocol | None = None
     _ports: policyrep.PortconRange | None = None
     ports_subset: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,7 @@ def mock_policy(mock_type, mock_typeattr, mock_user, mock_role) -> setools.SELin
 
     policy = Mock(setools.SELinuxPolicy)
     policy.mls = False
+    policy.target_platform = setools.PolicyTarget.selinux
     policy.bools.return_value = (foo_bool, bar_bool)
     policy.categories.return_value = (foo_cat, bar_cat)
     policy.classes.return_value = (foo_class, bar_class)


### PR DESCRIPTION
* SELinux and Xen query arguments are now defined in separate argument groups (`selinux` and `xen`), and the tool enforces that arguments from both groups cannot be combined in a single invocation. This ensures users do not mix incompatible queries. (`seinfo`, [seinfoL91-R121](diffhunk://#diff-a1dc70ae19a33ab848e21d7206a46138d32ebd84c6812c99d125057a616a8528L91-R121))
* At runtime, the tool checks the loaded policy's platform (SELinux or Xen) and raises errors if queries from the wrong group are specified, preventing platform mismatches. (`seinfo`, [seinfoR146-R153](diffhunk://#diff-a1dc70ae19a33ab848e21d7206a46138d32ebd84c6812c99d125057a616a8528R146-R153))

* Each query class now declares a `required_platform` attribute, specifying whether it is valid for SELinux or Xen policies. This helps prevent accidental misuse and improves code clarity. (`setools/fsusequery.py`, [[1]](diffhunk://#diff-c1720c8ea6e848db34a511f33edd48d5aa90ed46496c137746dfd7e7653501b2R47-R48); `setools/genfsconquery.py`, [[2]](diffhunk://#diff-961a4a41fa8733e305aa608293a5079bdd504a9f957d43671baddb888683f741R49-R50); `setools/ibpkeyconquery.py`, [[3]](diffhunk://#diff-fc794bbefe08f12625c86a915a06bb9df9d6eca8030cb017bbe54022d3defa08R54-R55); `setools/ibendportconquery.py`, [[4]](diffhunk://#diff-a7a853c81a2bee5c0d3d280adbae34540bba66d5824a55b17f23e7baf13658c2R46-R47); `setools/initsidquery.py`, [[5]](diffhunk://#diff-e8d2accde29bdad8d2fd3fb160729d4df2f6f95b0ce674a22166afa972e5b65bR45-R46); `setools/devicetreeconquery.py`, [[6]](diffhunk://#diff-af3c900769a6c93cdf93f62365f1c310d8c84a58392423b01f64ab7803a8021bR47-R48); `setools/iomemconquery.py`, [[7]](diffhunk://#diff-677827dcfc27c700beadd2f237b7c7c4fffa160478eb08f8af8cc516ace6f1d2R56-R57)

* The GitHub Actions workflow is updated to test against Python 3.13 and to use the latest `actions/setup-python@v6`, ensuring CI compatibility with newer Python versions. (`.github/workflows/tests.yml`, [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR33) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL44-R45)
