### PR TITLE
pyproject.toml: Set pytest to explicitly use PyQt6.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,25 +26,32 @@ jobs:
       fail-fast: false
 
       matrix:
-        build-opts:
-          - {python: '3.10', tox: python3}
-          - {python: '3.11', tox: python3}
-          - {python: '3.12', tox: python3}
-          - {python: '3.13', tox: python3}
+        # unit tests
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        tox:
+          - "python3"
+        include:
+          # static analysis
           - {python: '3.11', tox: pep8}
           - {python: '3.11', tox: lint}
           - {python: '3.11', tox: mypy}
           - {python: '3.11', tox: coverage}
+          # install test
           - {python: '3.11', tox: install}
 
     steps:
     - uses: actions/checkout@v3
 
     # This should be the minimum required Python version to build refpolicy.
-    - name: Set up Python ${{ matrix.build-opts.python }}
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.build-opts.python }}
+        python-version: ${{ matrix.python }}
 
     - name: Install dependencies
       run: |
@@ -90,6 +97,6 @@ jobs:
       run: |
         # confirm python version
         python --version
-        python -m tox -e ${{ matrix.build-opts.tox }}
+        python -m tox -e ${{ matrix.tox }}
       env:
         LD_LIBRARY_PATH: "${{env.SEPOL_SRC}}/src:${{env.SELINUX_SRC}}/src:${LD_LIBRARY_PATH}"

--- a/README.md
+++ b/README.md
@@ -76,17 +76,6 @@ and perform the following at the root:
 This will compile the C portion of SETools locally, and then
 the tools can be ran from the current directory (e.g. `./seinfo`).
 
-### Rebuilding the Apol Help File
-
-For convenience, a prebuilt copy of the apol help data file is included.
-To rebuild this file, the Qt5 development tools are required
-(particularly, the `qcollectiongenerator` tool).  At the root
-of the SETools sources, perform the following:
-
-```bash
-  $ python setup.py build_qhc
-```
-
 ### Installing SETools
 
 Unpack the official distribution or check out the git repository,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,10 +199,6 @@ persistent = true
 # Discover python modules and packages in the file system subtree.
 # recursive =
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode = true
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 # unsafe-load-any-extension =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -646,6 +646,7 @@ redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib",]
 pythonpath = "."
+qt_api = "pyqt6"
 markers = [
     "obj_args"
 ]


### PR DESCRIPTION
Additional tweaks:
* Remove deprecated pylint option
* Remove out of date Apol help file section from README.md
* Refine build matrix in GitHub actions

Fixes #160 