### PR TITLE
MCP server refinement

### DIFF
--- a/.github/actions/build-setools/action.yml
+++ b/.github/actions/build-setools/action.yml
@@ -28,6 +28,7 @@ runs:
     - name: Install build dependencies
       shell: bash
       run: |
+        echo "::group::Install build dependencies"
         sudo apt-get update -qq
         sudo apt-get install -qqy \
             libgraphviz-dev \
@@ -35,21 +36,26 @@ runs:
         # Use pip to ensure the packages go to the configured Python environment
         python -m pip install -U --user \
             cython \
-            setuptools \
+            setuptools
+        echo "::endgroup::"
 
     - name: Build sdist
       id: build-sdist
       shell: bash
       run: |
+        echo "::group::Build sdist"
         python setup.py sdist
         echo "sdistpath=$(find dist -type f -name '*.tar.gz')" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
 
     - name: Build wheel
       shell: bash
       id: build-wheel
       run: |
+        echo "::group::Build wheel"
         pip wheel --no-deps .
         echo "wheelpath=$(find . -type f -name '*.whl')" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
       env:
         CPPFLAGS: "-I${{inputs.userspace-path}}/usr/include"
         LD_LIBRARY_PATH: "${{inputs.userspace-path}}/lib:${{inputs.userspace-path}}/usr/lib:${LD_LIBRARY_PATH}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,11 @@ jobs:
     - name: Install unit test dependencies
       shell: bash
       run: |
+        echo "::group::Update system packages from apt"
         sudo apt-get update -qq
+        echo "::endgroup::"
+
+        echo "::group::Install unit test dependencies from apt"
         sudo apt-get install -qqy \
             libegl1 \
             libdbus-1-3 \
@@ -75,10 +79,13 @@ jobs:
             x11-utils \
             x11-xserver-utils \
             xvfb
+        echo "::endgroup::"
 
         # Use pip to ensure the packages go to the configured Python environment
+        echo "::group::Install unit test dependencies from pip"
         python -m pip install -U --user \
             tox
+        echo "::endgroup::"
 
     - name: Run unit tests/linting
       shell: bash

--- a/setools/dta.py
+++ b/setools/dta.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 #
 
-import enum
 import itertools
 import logging
 from collections import defaultdict
@@ -126,7 +125,7 @@ class DomainTransitionAnalysis(query.DirectedGraphAnalysis):
                 (default is none)
     """
 
-    class Mode(enum.Enum):
+    class Mode(policyrep.PolicyEnum):
 
         """Domain transition analysis modes"""
 

--- a/setools/infoflow.py
+++ b/setools/infoflow.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 #
-import enum
 import itertools
 import logging
 from collections.abc import Iterable, Mapping
@@ -49,7 +48,7 @@ class InfoFlowAnalysis(query.DirectedGraphAnalysis):
 
     """
 
-    class Mode(enum.Enum):
+    class Mode(policyrep.PolicyEnum):
 
         """Information flow analysis modes"""
 

--- a/setools/mcp/server.py
+++ b/setools/mcp/server.py
@@ -98,11 +98,9 @@ class SEToolsMCPServer:
         results: list[Any] = list(itertools.islice(query.results(), 0, max_results+1))
         truncated: bool = len(results) > max_results
         returned_count = len(results) if not truncated else max_results
-        return json.dumps({"count": returned_count,
-                           "truncated": truncated,
-                           "result": results[:max_results]},
-                          cls=MCPEncoder,
-                          indent=2)
+        return SEToolsMCPServer._serialize_results(results[:max_results],
+                                                   returned_count,
+                                                   truncated)
 
     def _load_policy(self, policy: str | None = None) -> SELinuxPolicy:
         """
@@ -110,6 +108,15 @@ class SEToolsMCPServer:
         If *policy* is None, uses the server default or the running system policy.
         """
         return self._policy_cache[policy if policy else self.default_policy]
+
+    @staticmethod
+    def _serialize_results(result: Any, count: int, truncated: bool) -> str:
+        """Serialize results to JSON."""
+        return json.dumps({"count": count,
+                           "truncated": truncated,
+                           "result": result},
+                          cls=MCPEncoder,
+                          indent=2)
 
     #
     # MCP Tools
@@ -123,10 +130,7 @@ class SEToolsMCPServer:
         ] = None,
     ) -> str:
         """Return statistics and metadata about an SELinux policy."""
-        return json.dumps({"count": 1,
-                           "truncated": False,
-                           "result": self._load_policy(policy_path)},
-                          cls=MCPEncoder, indent=2)
+        return self._serialize_results(self._load_policy(policy_path), 1, False)
 
     def setools_search_te_rules(
         self,
@@ -961,18 +965,7 @@ class SEToolsMCPServer:
                     break
                 results.append(transition)
 
-        return json.dumps(
-            {
-                "mode": mode,
-                "source": source,
-                "target": target,
-                "count": len(results),
-                "truncated": truncated,
-                "result": results,
-            },
-            cls=MCPEncoder,
-            indent=2,
-        )
+        return self._serialize_results(results, len(results), truncated)
 
     def setools_analyze_info_flow(
         self,
@@ -1057,15 +1050,7 @@ class SEToolsMCPServer:
                     break
                 results.append(step)
 
-        return json.dumps(
-            {
-                "count": len(results),
-                "truncated": truncated,
-                "result": results,
-            },
-            cls=MCPEncoder,
-            indent=2,
-        )
+        return self._serialize_results(results, len(results), truncated)
 
     def setools_diff_policies(
         self,
@@ -1236,14 +1221,4 @@ class SEToolsMCPServer:
                 "removed_truncated": trunc_r,
             }
 
-        return json.dumps(
-            {
-                "left_policy": left_policy,
-                "right_policy": right_policy,
-                "count": count,
-                "truncated": any_truncated,
-                "result": differences,
-            },
-            cls=MCPEncoder,
-            indent=2,
-        )
+        return self._serialize_results(differences, count, any_truncated)

--- a/setools/mcp/server.py
+++ b/setools/mcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 import ipaddress
 import itertools
 import json
@@ -30,9 +31,18 @@ __all__ = ("MCPEncoder",)
 
 TOOL_PREFIX: Final[str] = "setools_"
 
-_DIFF_COMPONENTS: Final[frozenset[str]] = frozenset(
-    {"te_rules", "rbac_rules", "types", "roles", "users", "portcons", "mls_rules"}
-)
+
+class DiffComponent(str, enum.Enum):
+
+    """Policy components that can be compared in a policy difference analysis."""
+
+    TE_RULES = "te_rules"
+    RBAC_RULES = "rbac_rules"
+    TYPES = "types"
+    ROLES = "roles"
+    USERS = "users"
+    PORTCONS = "portcons"
+    MLS_RULES = "mls_rules"
 
 
 class PolicyCache(dict):
@@ -1060,7 +1070,7 @@ class SEToolsMCPServer:
             list[str] | None,
             "Components to compare.  If omitted, defaults to: te_rules, rbac_rules, "
             "types, roles, users.  Available components: "
-            + ", ".join(sorted(_DIFF_COMPONENTS)),
+            + ", ".join(sorted(DiffComponent)),
         ] = None,
         max_per_component: Annotated[
             int,
@@ -1082,17 +1092,8 @@ class SEToolsMCPServer:
         right = SELinuxPolicy(right_policy)
         diff = PolicyDifference(left, right)
 
-        selected: set[str] = (
-            set(components)
-            if components
-            else {"te_rules", "rbac_rules", "types", "roles", "users"}
-        )
-        unknown = selected - _DIFF_COMPONENTS
-        if unknown:
-            raise ValueError(
-                f"Unknown component(s): {sorted(unknown)}.  "
-                f"Valid components: {sorted(_DIFF_COMPONENTS)}"
-            )
+        selected: set[DiffComponent] = {DiffComponent(c) for c in components} if components \
+            else {DiffComponent.TE_RULES}
 
         def _cap(items: Any, limit: int) -> tuple[list[Any], bool]:
             lst = sorted(items)
@@ -1102,7 +1103,7 @@ class SEToolsMCPServer:
         any_truncated = False
         differences: dict[str, Any] = {}
 
-        if "te_rules" in selected:
+        if DiffComponent.TE_RULES in selected:
             added, trunc_a = _cap(diff.added_allows, max_per_component)
             removed, trunc_r = _cap(diff.removed_allows, max_per_component)
             modified, trunc_m = _cap(diff.modified_allows, max_per_component)
@@ -1131,7 +1132,7 @@ class SEToolsMCPServer:
                 },
             }
 
-        if "types" in selected:
+        if DiffComponent.TYPES in selected:
             added, trunc_a = _cap(diff.added_types, max_per_component)
             removed, trunc_r = _cap(diff.removed_types, max_per_component)
             count += len(added) + len(removed)
@@ -1143,7 +1144,7 @@ class SEToolsMCPServer:
                 "removed_truncated": trunc_r,
             }
 
-        if "roles" in selected:
+        if DiffComponent.ROLES in selected:
             added, trunc_a = _cap(diff.added_roles, max_per_component)
             removed, trunc_r = _cap(diff.removed_roles, max_per_component)
             count += len(added) + len(removed)
@@ -1155,7 +1156,7 @@ class SEToolsMCPServer:
                 "removed_truncated": trunc_r,
             }
 
-        if "users" in selected:
+        if DiffComponent.USERS in selected:
             added, trunc_a = _cap(diff.added_users, max_per_component)
             removed, trunc_r = _cap(diff.removed_users, max_per_component)
             count += len(added) + len(removed)
@@ -1167,7 +1168,7 @@ class SEToolsMCPServer:
                 "removed_truncated": trunc_r,
             }
 
-        if "rbac_rules" in selected:
+        if DiffComponent.RBAC_RULES in selected:
             added_ra, trunc_a = _cap(diff.added_role_allows, max_per_component)
             removed_ra, trunc_r = _cap(diff.removed_role_allows, max_per_component)
             added_rt, trunc_at = _cap(diff.added_role_transitions, max_per_component)
@@ -1193,7 +1194,7 @@ class SEToolsMCPServer:
                 },
             }
 
-        if "mls_rules" in selected:
+        if DiffComponent.MLS_RULES in selected:
             added, trunc_a = _cap(diff.added_range_transitions, max_per_component)
             removed, trunc_r = _cap(diff.removed_range_transitions, max_per_component)
             count += len(added) + len(removed)
@@ -1209,7 +1210,7 @@ class SEToolsMCPServer:
                 },
             }
 
-        if "portcons" in selected:
+        if DiffComponent.PORTCONS in selected:
             added, trunc_a = _cap(diff.added_portcons, max_per_component)
             removed, trunc_r = _cap(diff.removed_portcons, max_per_component)
             count += len(added) + len(removed)

--- a/setools/mcp/server.py
+++ b/setools/mcp/server.py
@@ -933,29 +933,22 @@ class SEToolsMCPServer:
         Each transition step contains the source and target domain, the
         allow/type_transition rules that permit the transition, the entrypoint
         executables, setexec rules, and dynamic transition rules.
+
+        If the required dependency (NetworkX) is not installed, this method will
+        raise a NameError.
         """
-        try:
-            dta_mode = DomainTransitionAnalysis.Mode[mode]
-        except KeyError as e:
-            valid = sorted(m.name for m in DomainTransitionAnalysis.Mode)
-            raise ValueError(f"Invalid mode {mode!r}.  Valid modes: {valid}") from e
-
-        policy = self._load_policy(policy_path)
-
-        analysis = DomainTransitionAnalysis(
-            policy,
-            source=source,
-            target=target,
-            mode=dta_mode,
-            reverse=reverse,
-            depth_limit=depth_limit,
-            exclude=exclude,
-        )
+        analysis = DomainTransitionAnalysis(self._load_policy(policy_path),
+                                            source=source,
+                                            target=target,
+                                            mode=DomainTransitionAnalysis.Mode.lookup(mode),
+                                            reverse=reverse,
+                                            depth_limit=depth_limit,
+                                            exclude=exclude)
 
         results: list[Any] = []
         truncated = False
 
-        if dta_mode in DomainTransitionAnalysis.TRANSITIVE_MODES:
+        if analysis.mode in DomainTransitionAnalysis.TRANSITIVE_MODES:
             for path in analysis.results():
                 if len(results) >= max_results:
                     truncated = True
@@ -1035,30 +1028,23 @@ class SEToolsMCPServer:
 
         Each step includes the source and target types, the combined flow weight,
         and the allow rules that create the flow.
+
+        If the required dependency (NetworkX) is not installed, this method will
+        raise a NameError.
         """
-        try:
-            ifa_mode = InfoFlowAnalysis.Mode[mode]
-        except KeyError as e:
-            valid = sorted(m.name for m in InfoFlowAnalysis.Mode)
-            raise ValueError(f"Invalid mode {mode!r}.  Valid modes: {valid}") from e
-
-        policy = self._load_policy(policy_path)
-        perm_map = PermissionMap(perm_map_path)
-
-        analysis = InfoFlowAnalysis(
-            policy,
-            perm_map,
-            source=source,
-            target=target,
-            mode=ifa_mode,
-            min_weight=min_weight,
-            depth_limit=depth_limit,
-            exclude=exclude)
+        analysis = InfoFlowAnalysis(self._load_policy(policy_path),
+                                    PermissionMap(perm_map_path),
+                                    source=source,
+                                    target=target,
+                                    mode=InfoFlowAnalysis.Mode.lookup(mode),
+                                    min_weight=min_weight,
+                                    depth_limit=depth_limit,
+                                    exclude=exclude)
 
         results: list[Any] = []
         truncated = False
 
-        if ifa_mode in InfoFlowAnalysis.TRANSITIVE_MODES:
+        if analysis.mode in InfoFlowAnalysis.TRANSITIVE_MODES:
             for path in analysis.results():
                 if len(results) >= max_results:
                     truncated = True

--- a/tests/library/mcp/test_server.py
+++ b/tests/library/mcp/test_server.py
@@ -39,10 +39,10 @@ def mcp_server2(policy_pair: tuple) -> tuple[SEToolsMCPServer, str, str]:
     return mcp, left.path, right.path
 
 
-def assert_payload(payload: str, toplevel_key_count: int = 3) -> dict:
+def assert_payload(payload: str) -> dict:
     """Assert that the payload is valid JSON and contains expected top level keys."""
     data = json.loads(payload)
-    assert len(data) == toplevel_key_count, f"{data!r}"
+    assert len(data) == 3, f"{data!r}"
     assert "result" in data, f"{data!r}"
     assert "truncated" in data, f"{data!r}"
     assert isinstance(data["truncated"], bool), f"{data!r}"
@@ -69,8 +69,8 @@ class TestGetPolicyInfo:
 @pytest.mark.obj_args(XEN_POLICY, xen=True)
 class TestGetPolicyInfoXen:
     def test_xen_policy(self, mcp_server: SEToolsMCPServer) -> None:
-        result = assert_payload(mcp_server.setools_get_policy_info())
-        assert result["result"]["target_platform"] == "xen"
+        result = assert_payload(mcp_server.setools_get_policy_info())["result"]
+        assert result["target_platform"] == "xen"
 
 
 @pytest.mark.obj_args(SELINUX_POLICY)
@@ -540,22 +540,18 @@ class TestListDevicetreecons:
 class TestAnalyzeDTA:
     def test_transitions_out(self, mcp_server: SEToolsMCPServer) -> None:
         data = assert_payload(mcp_server.setools_analyze_dta(mode="TransitionsOut", source="start",
-                              max_results=5), 6)
-        assert data["mode"] == "TransitionsOut"
-        assert data["source"] == "start"
+                              max_results=5))
         assert data["count"] > 0
 
     def test_transitions_in(self, mcp_server: SEToolsMCPServer) -> None:
         data = assert_payload(mcp_server.setools_analyze_dta(mode="TransitionsIn", target="trans1",
-                              max_results=5), 6)
-        assert data["mode"] == "TransitionsIn"
-        assert data["target"] == "trans1"
+                              max_results=5))
         assert data["count"] > 0
 
     def test_shortest_paths(self, mcp_server: SEToolsMCPServer) -> None:
         # Find a target that kernel_t can reach
         data = assert_payload(mcp_server.setools_analyze_dta(mode="ShortestPaths", source="trans2",
-                              target="trans3", max_results=5), 6)
+                              target="trans3", max_results=5))
         assert data["count"] > 0
         assert isinstance(data["result"][0]["path"], list)
 
@@ -594,7 +590,7 @@ class TestDiffPolicies:
     def test_identical_policies(self, mcp_server2: tuple[SEToolsMCPServer, str, str]) -> None:
         server, left, _ = mcp_server2
         data = assert_payload(server.setools_diff_policies(
-            left, left, components=["types"],), toplevel_key_count=5)
+            left, left, components=["types"],))
         assert data["result"]["types"]["added"] == []
         assert data["result"]["types"]["removed"] == []
         assert data["count"] == 0
@@ -604,7 +600,7 @@ class TestDiffPolicies:
         # tests/library/mcp/diff_left.conf vs policy-full.33 differ in TE rules
         server, left, right = mcp_server2
         data = assert_payload(server.setools_diff_policies(
-            left, right, components=["te_rules", "types"]), toplevel_key_count=5)
+            left, right, components=["te_rules", "types"]))
         diffs = data["result"]
         # The two full policy files should differ in at least TE rules or types
         has_any_diff = (
@@ -627,7 +623,7 @@ class TestDiffPolicies:
                                           mcp_server2: tuple[SEToolsMCPServer, str, str]) -> None:
         server, left, right = mcp_server2
         data = assert_payload(server.setools_diff_policies(
-            left, right, components=["te_rules"]), toplevel_key_count=5)
+            left, right, components=["te_rules"]))
         te = data["result"]["te_rules"]
         for key in ("added_allows", "removed_allows", "modified_allows"):
             assert key in te
@@ -636,7 +632,7 @@ class TestDiffPolicies:
                                   mcp_server2: tuple[SEToolsMCPServer, str, str]) -> None:
         server, left, right = mcp_server2
         data = assert_payload(server.setools_diff_policies(
-            left, right, components=["rbac_rules"]), toplevel_key_count=5)
+            left, right, components=["rbac_rules"]))
         rbac = data["result"]["rbac_rules"]
         for key in ("added_role_allows", "removed_role_allows",
                     "added_role_transitions", "removed_role_transitions"):
@@ -646,7 +642,7 @@ class TestDiffPolicies:
                                  mcp_server2: tuple[SEToolsMCPServer, str, str]) -> None:
         server, left, right = mcp_server2
         data = assert_payload(server.setools_diff_policies(
-            left, right, components=["mls_rules"]), toplevel_key_count=5)
+            left, right, components=["mls_rules"]))
         mls = data["result"]["mls_rules"]
         for key in ("added_range_transitions", "removed_range_transitions"):
             assert key in mls
@@ -655,7 +651,7 @@ class TestDiffPolicies:
                                 mcp_server2: tuple[SEToolsMCPServer, str, str]) -> None:
         server, left, right = mcp_server2
         data = assert_payload(server.setools_diff_policies(
-            left, right, components=["portcons"]), toplevel_key_count=5)
+            left, right, components=["portcons"]))
         pc = data["result"]["portcons"]
         for key in ("added", "removed"):
             assert key in pc


### PR DESCRIPTION
This pull request refactors several parts of the `setools` codebase, primarily to improve enum handling, standardize JSON serialization, and simplify component selection logic for policy difference analysis. It also updates tests to align with these changes. The main themes are improved enum usage, serialization consistency, and code simplification.

**Enum and Component Handling Improvements:**

* Replaced usage of the standard `enum.Enum` with a custom `policyrep.PolicyEnum` for `Mode` inner classes in both `DomainTransitionAnalysis` and `InfoFlowAnalysis`, improving consistency and enabling custom lookup methods.
* Introduced a new `DiffComponent` enum to replace the previous frozenset of string constants for policy component selection in difference analysis, resulting in more robust and type-safe component handling throughout `setools/mcp/server.py`.

**JSON Serialization and API Response Standardization:**

* Centralized JSON serialization logic for API responses into a new static method `_serialize_results`, which is now used throughout the server for consistent formatting and reduced code duplication.

**Analysis Method Simplification:**

* Simplified mode lookup and error handling in `setools_analyze_dta` and `setools_analyze_info_flow` by leveraging the new enum lookup method, and adjusted references to analysis mode to use the new enum instances.
* Updated policy difference analysis to use the new `DiffComponent` enum for component selection and improved the logic for default and user-specified components.

**Test Updates:**

* Refactored test utilities and test cases in `tests/library/mcp/test_server.py` to match the new standardized API response format and removed now-unnecessary argument for top-level key count.

**Other Minor Cleanups:**

* Removed unused imports and updated imports to reflect new enum usage.