### PR TITLE
fscontext.pxi: Fix cython type decl string warning.

### DIFF
--- a/setools/policyrep/fscontext.pxi
+++ b/setools/policyrep/fscontext.pxi
@@ -79,7 +79,7 @@ cdef class GenfsFiletype(int):
                        "chr_file": S_IFCHR}
 
     @classmethod
-    def from_class(cls, tclass: ObjClass | str) -> "GenfsFiletype":
+    def from_class(cls, tclass: ObjClass | str) -> GenfsFiletype:
         """Create a GenfsFiletype from an object class."""
         name = tclass if isinstance(tclass, str) else tclass.name
         return cls(cls._sclass_to_stat[name])


### PR DESCRIPTION
Addresses:

warning: setools/policyrep/fscontext.pxi:82:51:
Strings should no longer be used for type
declarations. Use 'cython.int' etc. directly.